### PR TITLE
add MCS workflow notebook

### DIFF
--- a/notebooks/05_mcs_workflow_example.ipynb
+++ b/notebooks/05_mcs_workflow_example.ipynb
@@ -1,0 +1,2306 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "aa98ae2e-64a1-4b4b-a457-2e348c512954",
+   "metadata": {},
+   "source": [
+    "**Important**: This notebook only works together with the oggm dev branch at the moment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f1695663-3eab-4aa2-874f-b05301cb53f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from oggm import utils, workflow, tasks, cfg\n",
+    "from oggm.core.massbalance import MonthlyTIModel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47ab70e5-65bb-4956-ab5d-fbf60d3a2c09",
+   "metadata": {},
+   "source": [
+    "# Set up a gdir to play with"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "da584d25-d4fe-493b-a7a5-97aec7635be4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:04: oggm.cfg: Reading default parameters from the OGGM `params.cfg` configuration file.\n",
+      "2025-08-29 13:06:04: oggm.cfg: Multiprocessing switched OFF according to the parameter file.\n",
+      "2025-08-29 13:06:04: oggm.cfg: Multiprocessing: using all available processors (N=8)\n"
+     ]
+    }
+   ],
+   "source": [
+    "cfg.initialize(logging_level=\"WARNING\")\n",
+    "\n",
+    "working_dir = 'working_dir_mcs'\n",
+    "utils.mkdir(working_dir)\n",
+    "cfg.PATHS[\"working_dir\"] = working_dir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "bbf0de4d-26b5-474b-a142-ac6fc9d256ff",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:04: oggm.workflow: init_glacier_directories from prepro level 3 on 1 glaciers.\n",
+      "2025-08-29 13:06:04: oggm.workflow: Execute entity tasks [gdir_from_prepro] on 1 glaciers\n"
+     ]
+    }
+   ],
+   "source": [
+    "rgi_ids = [\"RGI60-06.00377\"]\n",
+    "base_url = 'https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/L3-L5_files/2023.3/elev_bands/W5E5/'\n",
+    "gdirs = workflow.init_glacier_directories(\n",
+    "        rgi_ids,\n",
+    "        from_prepro_level=3,\n",
+    "        prepro_border=10,\n",
+    "        prepro_rgi_version=\"62\",\n",
+    "        prepro_base_url=base_url,\n",
+    "    )\n",
+    "\n",
+    "gdir = gdirs[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e97b3f0e-5b4e-41e1-81f8-ef82ce4b02a2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:04: oggm.workflow: Execute entity tasks [mb_calibration_from_hugonnet_mb] on 1 glaciers\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Redo calibration to get the observations values stored in the observations file (prepro gdirs are not created with dev)\n",
+    "workflow.execute_entity_task(tasks.mb_calibration_from_hugonnet_mb,\n",
+    "                             gdirs,\n",
+    "                             informed_threestep=True,  # only available for 'GSWP3_W5E5'\n",
+    "                            );"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0b0a34c-400e-4139-bcc1-7bbdde745854",
+   "metadata": {},
+   "source": [
+    "# Define a workflow to play with"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b485e57a-23ff-48b6-b042-95da34ae8e7b",
+   "metadata": {},
+   "source": [
+    "Here you need to define a function which takes all parameters which are included in the uncertainty porpagation. Those parameters include observations (in my example reference mass balance `ref_mb`) and model parameters (in my example `melt_f`, `prcp_fac` and `temp_bias`). The function should conduct the calibration and potentially also a dynamic model run. All results should be stored using the `settings_filesuffix`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ed66f28b-ddd9-493b-9536-dc3aa15d2732",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mcs_mb_calibration(gdir, settings_filesuffix, settings_parent_filesuffix,\n",
+    "                       observations_filesuffix,\n",
+    "                       ref_mb, ref_mb_period, ref_mb_err,\n",
+    "                       prcp_fac, melt_f, temp_bias,\n",
+    "                      ):\n",
+    "    # add observations data to observations file\n",
+    "    gdir.observations_filesuffix = observations_filesuffix\n",
+    "    gdir.observations['ref_mb'] = {'err': ref_mb_err,\n",
+    "                                   'period': ref_mb_period,\n",
+    "                                   'value': ref_mb}\n",
+    "\n",
+    "    # create the new settings file with the correct parent_filesuffix\n",
+    "    utils.ModelSettings(gdir, filesuffix=settings_filesuffix,\n",
+    "                        parent_filesuffix=settings_parent_filesuffix)\n",
+    "    gdir.settings_filesuffix = settings_filesuffix\n",
+    "    gdir.settings['use_winter_prcp_fac'] = False  # this is checked in mb_calibration_from_scalar_mb\n",
+    "\n",
+    "    # the settings here mimic mb_calibration_from_hugonnet_mb\n",
+    "    workflow.execute_entity_task(tasks.mb_calibration_from_scalar_mb,\n",
+    "                                 gdir,\n",
+    "                                 settings_filesuffix=settings_filesuffix,\n",
+    "                                 observations_filesuffix=observations_filesuffix,\n",
+    "                                 overwrite_gdir=True,\n",
+    "                                 calibrate_param1='prcp_fac',\n",
+    "                                 calibrate_param2='melt_f',\n",
+    "                                 calibrate_param3='temp_bias',\n",
+    "                                 prcp_fac=prcp_fac,\n",
+    "                                 prcp_fac_min=prcp_fac * 0.8,\n",
+    "                                 prcp_fac_max=prcp_fac * 1.2,\n",
+    "                                 melt_f=melt_f,\n",
+    "                                 temp_bias=temp_bias,\n",
+    "                                 mb_model_class=MonthlyTIModel,\n",
+    "                                )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49fb66da-c079-47b1-9d4b-0895096ed7da",
+   "metadata": {},
+   "source": [
+    "# Create sample of input parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "482aee02-7dfb-439d-bb4c-c5ec7740bd19",
+   "metadata": {},
+   "source": [
+    "Here we define the distribution of the parameters we consider (observations and model parameters). This example here was just a quick setup for testing the principle workflow and need to be refined carefully depending on the application and the used type of observation. \n",
+    "\n",
+    "Here an overview which kind of distributions can be used and the meaning of 'bounds' depending on the selected distribution: https://salib.readthedocs.io/en/latest/user_guide/advanced.html#generating-alternate-distributions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2296c383-fd7e-41ce-bc1d-b222d5c948a0",
+   "metadata": {},
+   "source": [
+    "## define parameter distributions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a1d3946-47c9-4543-93e0-fe57a89840da",
+   "metadata": {},
+   "source": [
+    "I included here a small in between step for defining the parameters in a more readable way and only at the end convert it into the format which is expected by the sampler."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d787af9b-25be-492b-8b0d-0bfa5f5914b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# to have a better overview I provide the parameter distribution in a more readable way first\n",
+    "parameter_distribution = {}\n",
+    "\n",
+    "# add geodetic mb observation\n",
+    "gdir.observations_filesuffix = ''  # just to be sure to use the correct observations\n",
+    "ref_mb = gdir.observations['ref_mb']\n",
+    "parameter_distribution['ref_mb'] = {\n",
+    "    'bounds': [ref_mb['value'] - ref_mb['err'],  # this need to be checked again if we should use +/-err/2\n",
+    "               ref_mb['value'] + ref_mb['err']],\n",
+    "    'dists': 'unif'  # need to be checked\n",
+    "}\n",
+    "\n",
+    "# add mb parameter distributions (they are made up and need to be decided somehow)\n",
+    "gdir.settings_filesuffix = ''\n",
+    "parameter_distribution['prcp_fac'] = {\n",
+    "    'bounds': [max(gdir.settings['prcp_fac'] * 0.5, gdir.settings['prcp_fac_min']),\n",
+    "               min(gdir.settings['prcp_fac'] * 1.5, gdir.settings['prcp_fac_max'])\n",
+    "              ],\n",
+    "    'dists': 'unif'\n",
+    "}\n",
+    "parameter_distribution['melt_f'] = {\n",
+    "    'bounds': [max(gdir.settings['melt_f'] - 1, gdir.settings['melt_f_min']),\n",
+    "               min(gdir.settings['melt_f'] + 1, gdir.settings['melt_f_max'])],\n",
+    "    'dists': 'unif'\n",
+    "}\n",
+    "parameter_distribution['temp_bias'] = {\n",
+    "    'bounds': [max(gdir.settings['temp_bias'] - 0.5, gdir.settings['temp_bias_min']),\n",
+    "               min(gdir.settings['temp_bias'] + 0.5, gdir.settings['temp_bias_max'])],\n",
+    "    'dists': 'unif'\n",
+    "}\n",
+    "\n",
+    "# now convert to format which is expected by SALib\n",
+    "num_vars = 0\n",
+    "problem = {\n",
+    "    'names': [],\n",
+    "    'bounds': [],\n",
+    "    'dists': [],\n",
+    "}\n",
+    "\n",
+    "for key in parameter_distribution:\n",
+    "    num_vars += 1\n",
+    "    problem['names'].append(key)\n",
+    "    problem['bounds'].append(parameter_distribution[key]['bounds'])\n",
+    "    problem['dists'].append(parameter_distribution[key]['dists'])\n",
+    "problem['num_vars'] = num_vars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e1bf0bcd-62a9-4e81-8117-ef4ffb650c7b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'names': ['ref_mb', 'prcp_fac', 'melt_f', 'temp_bias'],\n",
+       " 'bounds': [[-700.3000000000001, -564.9],\n",
+       "  [1.1682545377091955, 3.5047636131275866],\n",
+       "  [4.0, 6.0],\n",
+       "  [-0.7619605322613461, 0.23803946773865398]],\n",
+       " 'dists': ['unif', 'unif', 'unif', 'unif'],\n",
+       " 'num_vars': 4}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "problem"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cc3c318-524d-4413-9a29-7b4eb528b8e0",
+   "metadata": {},
+   "source": [
+    "## create actual samples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ccde8b3d-54e4-4d34-b13e-f5819fab6c17",
+   "metadata": {},
+   "source": [
+    "Creating the actual sample is quite easy again. For more information on the sampling method you can read up the references provided in the sampler docstring `sampler.sample?`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "de28f5c9-1b35-4ff4-9418-169232c82f0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import SALib.sample.sobol as sampler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "32171be0-2414-4ae5-a43f-de3a1e07cae9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sampler.sample?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "85e94373-48a4-4805-986c-84793066fe40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# the total number of samples created is \n",
+    "# - including second order interconnections: N * (2 * num_vars + 2)\n",
+    "# - or only look at uncorrelated sensitivity with calc_second_order=False: N * (num_vars + 2)\n",
+    "N = 2**5  # if using second order this needs to be a power of 2\n",
+    "param_values = sampler.sample(problem, N, calc_second_order=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "5e4eacff-1311-4027-9bfe-ace82435fe31",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(320, 4)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "param_values.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a2ee4e6-06be-4c47-b591-d602618ac9cc",
+   "metadata": {},
+   "source": [
+    "# execute a calibration for each parameter setting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9958059c-9b04-47a1-aab5-4d9dec3a0bcf",
+   "metadata": {},
+   "source": [
+    "Here I loop through all samples and execute my function I defined above. For this we probably could utilize multiprocessing in the future (one option would be to make our function an entity_task and use the execute_entity_task logic)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "20ce8de0-687b-4137-9e81-b6ce6326591e",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:09: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:09: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:09: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:09: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1/320\n",
+      "2/320\n",
+      "3/320\n",
+      "4/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:09: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:09: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:09: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:09: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5/320\n",
+      "6/320\n",
+      "7/320\n",
+      "8/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "9/320\n",
+      "10/320\n",
+      "11/320\n",
+      "12/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "13/320\n",
+      "14/320\n",
+      "15/320\n",
+      "16/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "17/320\n",
+      "18/320\n",
+      "19/320\n",
+      "20/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21/320\n",
+      "22/320\n",
+      "23/320\n",
+      "24/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:10: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "25/320\n",
+      "26/320\n",
+      "27/320\n",
+      "28/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "29/320\n",
+      "30/320\n",
+      "31/320\n",
+      "32/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "33/320\n",
+      "34/320\n",
+      "35/320\n",
+      "36/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "37/320\n",
+      "38/320\n",
+      "39/320\n",
+      "40/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:11: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "41/320\n",
+      "42/320\n",
+      "43/320\n",
+      "44/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "45/320\n",
+      "46/320\n",
+      "47/320\n",
+      "48/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "49/320\n",
+      "50/320\n",
+      "51/320\n",
+      "52/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "53/320\n",
+      "54/320\n",
+      "55/320\n",
+      "56/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "57/320\n",
+      "58/320\n",
+      "59/320\n",
+      "60/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:12: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "61/320\n",
+      "62/320\n",
+      "63/320\n",
+      "64/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "65/320\n",
+      "66/320\n",
+      "67/320\n",
+      "68/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "69/320\n",
+      "70/320\n",
+      "71/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "72/320\n",
+      "73/320\n",
+      "74/320\n",
+      "75/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:13: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "76/320\n",
+      "77/320\n",
+      "78/320\n",
+      "79/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "80/320\n",
+      "81/320\n",
+      "82/320\n",
+      "83/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "84/320\n",
+      "85/320\n",
+      "86/320\n",
+      "87/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "88/320\n",
+      "89/320\n",
+      "90/320\n",
+      "91/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:14: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "92/320\n",
+      "93/320\n",
+      "94/320\n",
+      "95/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "96/320\n",
+      "97/320\n",
+      "98/320\n",
+      "99/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100/320\n",
+      "101/320\n",
+      "102/320\n",
+      "103/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "104/320\n",
+      "105/320\n",
+      "106/320\n",
+      "107/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "108/320\n",
+      "109/320\n",
+      "110/320\n",
+      "111/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:15: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "112/320\n",
+      "113/320\n",
+      "114/320\n",
+      "115/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "116/320\n",
+      "117/320\n",
+      "118/320\n",
+      "119/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "120/320\n",
+      "121/320\n",
+      "122/320\n",
+      "123/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "124/320\n",
+      "125/320\n",
+      "126/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:16: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "127/320\n",
+      "128/320\n",
+      "129/320\n",
+      "130/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "131/320\n",
+      "132/320\n",
+      "133/320\n",
+      "134/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "135/320\n",
+      "136/320\n",
+      "137/320\n",
+      "138/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "139/320\n",
+      "140/320\n",
+      "141/320\n",
+      "142/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "143/320\n",
+      "144/320\n",
+      "145/320\n",
+      "146/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:17: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "147/320\n",
+      "148/320\n",
+      "149/320\n",
+      "150/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "151/320\n",
+      "152/320\n",
+      "153/320\n",
+      "154/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "155/320\n",
+      "156/320\n",
+      "157/320\n",
+      "158/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "159/320\n",
+      "160/320\n",
+      "161/320\n",
+      "162/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:18: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "163/320\n",
+      "164/320\n",
+      "165/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "166/320\n",
+      "167/320\n",
+      "168/320\n",
+      "169/320\n",
+      "170/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "171/320\n",
+      "172/320\n",
+      "173/320\n",
+      "174/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "175/320\n",
+      "176/320\n",
+      "177/320\n",
+      "178/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:19: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "179/320\n",
+      "180/320\n",
+      "181/320\n",
+      "182/320\n",
+      "183/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "184/320\n",
+      "185/320\n",
+      "186/320\n",
+      "187/320\n",
+      "188/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "189/320\n",
+      "190/320\n",
+      "191/320\n",
+      "192/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "193/320\n",
+      "194/320\n",
+      "195/320\n",
+      "196/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:20: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "197/320\n",
+      "198/320\n",
+      "199/320\n",
+      "200/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "201/320\n",
+      "202/320\n",
+      "203/320\n",
+      "204/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "205/320\n",
+      "206/320\n",
+      "207/320\n",
+      "208/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "209/320\n",
+      "210/320\n",
+      "211/320\n",
+      "212/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "213/320\n",
+      "214/320\n",
+      "215/320\n",
+      "216/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:21: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "217/320\n",
+      "218/320\n",
+      "219/320\n",
+      "220/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "221/320\n",
+      "222/320\n",
+      "223/320\n",
+      "224/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "225/320\n",
+      "226/320\n",
+      "227/320\n",
+      "228/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "229/320\n",
+      "230/320\n",
+      "231/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:22: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "232/320\n",
+      "233/320\n",
+      "234/320\n",
+      "235/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "236/320\n",
+      "237/320\n",
+      "238/320\n",
+      "239/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "240/320\n",
+      "241/320\n",
+      "242/320\n",
+      "243/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "244/320\n",
+      "245/320\n",
+      "246/320\n",
+      "247/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "248/320\n",
+      "249/320\n",
+      "250/320\n",
+      "251/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:23: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "252/320\n",
+      "253/320\n",
+      "254/320\n",
+      "255/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "256/320\n",
+      "257/320\n",
+      "258/320\n",
+      "259/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "260/320\n",
+      "261/320\n",
+      "262/320\n",
+      "263/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "264/320\n",
+      "265/320\n",
+      "266/320\n",
+      "267/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:24: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "268/320\n",
+      "269/320\n",
+      "270/320\n",
+      "271/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "272/320\n",
+      "273/320\n",
+      "274/320\n",
+      "275/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "276/320\n",
+      "277/320\n",
+      "278/320\n",
+      "279/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "280/320\n",
+      "281/320\n",
+      "282/320\n",
+      "283/320\n",
+      "284/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "285/320\n",
+      "286/320\n",
+      "287/320\n",
+      "288/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:25: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "289/320\n",
+      "290/320\n",
+      "291/320\n",
+      "292/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "293/320\n",
+      "294/320\n",
+      "295/320\n",
+      "296/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "297/320\n",
+      "298/320\n",
+      "299/320\n",
+      "300/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "301/320\n",
+      "302/320\n",
+      "303/320\n",
+      "304/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:26: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "305/320\n",
+      "306/320\n",
+      "307/320\n",
+      "308/320\n",
+      "309/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:27: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:27: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:27: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:27: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:27: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "310/320\n",
+      "311/320\n",
+      "312/320\n",
+      "313/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:27: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:27: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:27: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:27: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "314/320\n",
+      "315/320\n",
+      "316/320\n",
+      "317/320\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-08-29 13:06:27: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:27: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n",
+      "2025-08-29 13:06:27: oggm.workflow: Execute entity tasks [mb_calibration_from_scalar_mb] on 1 glaciers\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "318/320\n",
+      "319/320\n",
+      "320/320\n"
+     ]
+    }
+   ],
+   "source": [
+    "# for the reference mass balance we provide the same error and mb_period as the original observation\n",
+    "gdir.observations_filesuffix = ''\n",
+    "ref_mb = gdir.observations['ref_mb']\n",
+    "\n",
+    "for i, param_val in enumerate(param_values):\n",
+    "    print(f\"{i + 1}/{param_values.shape[0]}\")\n",
+    "    mcs_mb_calibration(gdir,\n",
+    "                       settings_filesuffix=f'_{i}',\n",
+    "                       settings_parent_filesuffix='',\n",
+    "                       observations_filesuffix=f'_{i}',\n",
+    "                       ref_mb_period=ref_mb['period'],\n",
+    "                       ref_mb_err=ref_mb['err'],\n",
+    "                       ref_mb=param_val[problem['names'].index('ref_mb')],\n",
+    "                       prcp_fac=param_val[problem['names'].index('prcp_fac')],\n",
+    "                       melt_f=param_val[problem['names'].index('melt_f')],\n",
+    "                       temp_bias=param_val[problem['names'].index('temp_bias')],\n",
+    "                      )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f304272c-f37b-44a1-ab65-68a16860400c",
+   "metadata": {},
+   "source": [
+    "# Look at results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a7d0e8a6-6a77-4ea4-843d-8bf7f855518a",
+   "metadata": {},
+   "source": [
+    "## resulting distribution of mb parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "360791af-4456-412d-9a73-a2e95c72ae06",
+   "metadata": {},
+   "source": [
+    "Here just look at the resulting mass balance parameters after calibration. We initialized all with a uniform distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "0729b8bf-289d-41e6-bbb8-5be86c9f1df0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# default run parameters\n",
+    "gdir.settings_filesuffix = ''\n",
+    "prcp_fac_default = gdir.settings['prcp_fac']\n",
+    "melt_f_default = gdir.settings['melt_f']\n",
+    "temp_bias_default = gdir.settings['temp_bias']\n",
+    "\n",
+    "prcp_fac_all = []\n",
+    "melt_f_all  =[]\n",
+    "temp_bias_all = []\n",
+    "\n",
+    "for i in range(param_values.shape[0]):\n",
+    "    gdir.settings_filesuffix = f'_{i}'\n",
+    "    prcp_fac_all.append(gdir.settings['prcp_fac'])\n",
+    "    melt_f_all.append(gdir.settings['melt_f'])\n",
+    "    temp_bias_all.append(gdir.settings['temp_bias'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "961d3319-5ff5-473d-9611-bce6f6179c24",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAh8AAAGxCAYAAADCo9TSAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAABBvklEQVR4nO3daXgUVfr38V9n6yQEwp6EIZLIEsIOwrAKAWVTGBYRRhTZRJFFIwoIigZwWAVB0SCILCoCCjg+f/bRALIpIIwoiIBhGYUBEQgkZOmknhdMWpskDUknlXT4fq6rL2o5Xeeu6qZy9zlVpyyGYRgCAAAwiUdhBwAAAO4sJB8AAMBUJB8AAMBUJB8AAMBUJB8AAMBUJB8AAMBUJB8AAMBUJB8AAMBUJB8AAMBUJB8AirQDBw6oTZs2CgwMlMVi0Zw5cwo7JAAusjC8OoCirGHDhkpMTNTcuXNVpkwZhYWFKTg4uLDDAuACkg8At+X69evy8/MzvV5vb28NGTJE77zzjul1AygYdLsAd5CYmBhZLBYdOHBAPXv2VKlSpRQYGKjHHntMFy5csJcLCwtTly5dtGbNGjVs2FC+vr6aOHGiJOmXX37Rk08+qdDQUPn4+KhSpUrq1auX/vvf/0qStm7dKovFog8//FCjRo1ScHCw/Pz81KZNGx04cOC2Y12yZIksFotsNptiY2NlsVhksVgkSRcuXNCwYcNUq1YtBQQEqGLFimrXrp2++uqrLNtJSUnRpEmTFBkZKV9fX5UrV05t27bVrl27XDmUAFzgVdgBADBfjx491Lt3bw0dOlQ//PCDJkyYoMOHD+vrr7+Wt7e3JOnbb7/VkSNH9PLLLys8PFwlSpTQL7/8oiZNmigtLU3jx49XvXr1dPHiRW3atEmXLl1SUFCQvY7x48erUaNGeu+993TlyhXFxMQoKipKBw4c0N13333LGB988EHt3r1bzZs3V69evfT888/b1/3++++SpFdffVXBwcG6du2a1q5dq6ioKH3xxReKioqSJNlsNnXu3FlfffWVoqOj1a5dO9lsNu3Zs0enT59WixYt8vGoArhtBoA7xquvvmpIMp577jmH5R999JEhyfjwww8NwzCMKlWqGJ6ensbRo0cdyg0aNMjw9vY2Dh8+nGMdcXFxhiSjUaNGRkZGhn35yZMnDW9vb+OJJ57IVcySjOHDhzstY7PZjLS0NOO+++4zevToYV++bNkyQ5KxcOHCXNUJoGDR7QLcgR599FGH+d69e8vLy0txcXH2ZfXq1VONGjUcym3YsEFt27ZVZGTkLevo27evvZtEkqpUqaIWLVo41OGK+fPnq1GjRvL19ZWXl5e8vb31xRdf6MiRIw7x+vr6atCgQflSJ4D8QfIB3IFuvlvEy8tL5cqV08WLF+3LQkJCsrzvwoULqly5cp7qyFz25zryavbs2Xr66afVtGlTrV69Wnv27NHevXvVqVMnXb9+3SHeSpUqycODUx1QlHDNB3AHOnfunP7yl7/Y5202my5evKhy5crZl/251SJThQoV9J///Oe268hu2Z/ryKsPP/xQUVFRio2NdVh+9epVh/kKFSpox44dysjIIAEBihD+NwJ3oI8++shhftWqVbLZbPYLNXPSuXNnxcXF6ejRo7es4+OPP5bxpzv5T506pV27dt2yjtthsVhktVodln333XfavXt3lniTk5O1ZMkSl+sEkH9o+QDuQGvWrJGXl5fat29vv9ulfv366t27t9P3TZo0SRs2bFDr1q01fvx41a1bV5cvX9bGjRs1atQo1axZ0172/Pnz6tGjh4YMGaIrV67o1Vdfla+vr8aNG+dy/F26dNHkyZP16quvqk2bNjp69KgmTZqk8PBw2Ww2e7lHHnlEixcv1tChQ3X06FG1bdtWGRkZ+vrrrxUZGam///3vLscCIPdIPoA70Jo1axQTE2MfP6Nr166aM2eOfHx8nL7vL3/5i7755hu9+uqrmjZtmi5evKgKFSqoVatWKlu2rEPZKVOmaO/evRo4cKASEhL017/+VStWrFDVqlVdjv+ll15SUlKSFi1apBkzZqhWrVqaP3++1q5dq61bt9rLeXl5af369Zo6dao+/vhjzZkzRyVLllT9+vXVqVMnl+MAkDeMcArcQWJiYjRx4kRduHBB5cuXL5A6tm7dqrZt2+qTTz5Rr169CqQOAO6Naz4AAICp6HYBYDrDMJSenu60jKenZ7Z33ABwf3S7ADBdZteMM4sXL9aAAQPMCQiAqUg+AJju6tWrt7xdNzw8PF/GBAFQ9JB8AAAAU3HBKQAAMFWRu+A0IyNDv/76q0qWLMnFZgAAuAnDMHT16tXbep5SkUs+fv31V4WGhhZ2GAAAIA/OnDlzywdQ5ir5iI2NVWxsrE6ePClJql27tl555RV17txZ0o2sZ+LEiVqwYIEuXbqkpk2b6u2331bt2rVvu46SJUvagy9VqlRuwgNQWFITpVkRN6afPyr5lMifspISExNVqVIlSTd+nJQo4bw8gMKRkJCg0NBQ+99xZ3KVfFSuXFnTpk1TtWrVJElLly5Vt27ddODAAdWuXVszZszQ7NmztWTJEtWoUUOvvfaa2rdvr6NHj95WMNIfT9IsVaoUyQfgLlI9Jev/uklLlbpF8pGLsrox3kemUqVKkXwARdztXDKRqwtOu3btqgceeEA1atRQjRo19I9//EMBAQHas2ePDMPQnDlz9NJLL6lnz56qU6eOli5dqqSkJC1fvjzPOwEAAIqXPN/tkp6erhUrVigxMVHNmzdXfHy8zp07pw4dOtjLWK1WtWnTRrt27cpxOykpKUpISHB4AXAzHl5S/b43Xh5F7lIyAEVMrs8Shw4dUvPmzZWcnKyAgACtXbtWtWrVsicYQUFBDuWDgoJ06tSpHLc3depUTZw4MbdhAChKvKxSj9jCjgKAm8h18hEREaGDBw/q8uXLWr16tfr3769t27bZ19/c12MYhtP+n3HjxmnUqFH2+cwLVpwxDEM2m+2Wz4YAiiNvb2+H6yAAwN3kOvnw8fGxX3DauHFj7d27V3PnztXYsWMlSefOnVNISIi9/Pnz57O0hvyZ1WqV1Wq97fpTU1N19uxZJSUl5TZ0oFiwWCyqXLmyAgICCjuUPxiGlPa//5Pe/hJj9ABwwuXOWcMwlJKSovDwcAUHB2vLli1q2LChpBuJwrZt2zR9+nSXA5VuDEAWHx8vT09PVapUST4+PgxEhjuKYRi6cOGC/vOf/6h69epFpwUkLUmacuN2WI3/9ZZ3sAC4s+Uq+Rg/frw6d+6s0NBQXb16VStWrNDWrVu1ceNGWSwWRUdHa8qUKapevbqqV6+uKVOmyN/fX3379s2XYFNTU5WRkaHQ0FD5+/vnyzYBd1OhQgWdPHlSaWlpRSf5AIBcyFXy8d///lf9+vXT2bNnFRgYqHr16mnjxo1q3769JGnMmDG6fv26hg0bZh9kbPPmzbc9xsftutWwrUBxRmsfAHeXq+Rj0aJFTtdbLBbFxMQoJibGlZgAAEAxRhMCAAAwFckHsrVkyRKVLl26sMMAABRDJB/FSFhYmObMmVPYYQAA4BTjIN9h0tPTZbFYCuSi3bS0NHl7e+f7duEGLJ5SrW5/TAOAE27f8mEYhhITEwvlZRjGbceZkZGh6dOnq1q1arJarbrrrrv0j3/8w77+0KFDateunfz8/FSuXDk9+eSTunbtmn39gAED1L17d73++usKCQlRuXLlNHz4cKWlpUmSoqKidOrUKT333HOyWCz2OyIyu0/+7//+T7Vq1ZLVatWpU6d06dIlPf744ypTpoz8/f3VuXNnHTt27Lb35+TJk7JYLFq1apWioqLk6+urDz/8UDExMWrQoIFD2Tlz5igsLOy29wVuyNtX6r3sxsvbt7CjAVDEuX3LR1JSUqGN9Hjt2rXbfrz3uHHjtHDhQr3xxhtq1aqVzp49qx9//FHSjX3o1KmTmjVrpr179+r8+fN64oknNGLECC1ZssS+jbi4OIWEhCguLk7Hjx9Xnz591KBBAw0ZMkRr1qxR/fr19eSTT2rIkCEOdSclJWnq1Kl67733VK5cOVWsWFF9+/bVsWPH9Pnnn6tUqVIaO3asHnjgAR0+fDhXrRdjx47VrFmztHjxYlmtVi1YsOC23udsX4CiKOzFdQWy3ZPTHiyQ7QJFmdsnH+7g6tWrmjt3rubNm6f+/ftLkqpWrapWrVpJkj766CNdv35dy5Ytsycz8+bNU9euXTV9+nT78PRlypTRvHnz5OnpqZo1a+rBBx/UF198oSFDhqhs2bLy9PRUyZIlFRwc7FB/Wlqa3nnnHdWvX1+S7EnHzp071aJFC3sMoaGh+uyzz/Twww/f9r5FR0erZ8+euT4mzvYFAFC8uX3y4e/v79A9YXbdt+PIkSNKSUnRfffdl+P6+vXrO7SitGzZUhkZGTp69Kg9+ahdu7bDiJYhISE6dOjQLev38fFRvXr1HOrz8vJS06ZN7cvKlSuniIgIHTly5Lb2KVPjxo1zVT5TXvcFRVRqIsOrA7htbp98WCyW2+76KCx+fn5O1zt78u+fl9/cHWKxWJSRkXFb9f95Ozldq3KrJxBn5+Zj7+HhkWX72V3Lkdd9AQC4P7e/4NQdVK9eXX5+fvriiy+yXV+rVi0dPHhQiYmJ9mU7d+6Uh4eHatSocdv1+Pj4KD09/ZblatWqJZvNpq+//tq+7OLFi/rpp58UGRl52/Vlp0KFCjp37pxDAnLw4EGXtgkAKF5IPkzg6+ursWPHasyYMVq2bJlOnDihPXv22Ierf/TRR+Xr66v+/fvr+++/V1xcnEaOHKl+/frZu1xuR1hYmLZv365ffvlFv/32W47lqlevrm7dumnIkCHasWOH/v3vf+uxxx7TX/7yF3Xr1s2lfY2KitKFCxc0Y8YMnThxQm+//bY2bNjg0jYBAMULyYdJJkyYoOeff16vvPKKIiMj1adPH50/f17SjWtHNm3apN9//11NmjRRr169dN9992nevHm5qmPSpEk6efKkqlatqgoVKjgtu3jxYt1zzz3q0qWLmjdvLsMwtH79epfH6YiMjNQ777yjt99+W/Xr19c333yjF154waVtAgCKF4uRm8EqTJCQkKDAwEBduXJFpUqVcliXnJys+Ph4hYeHy9eXsQRwZyqS/w9yc8FpLi9OTUxMtN9On5vb2/Mbt9oCzjn7+30zWj4AAICp3P5uFwBFgMVTqt7hj2kAcILkA4DrvH2lRz8p7CgAuAm6XQAAgKlIPgAAgKlIPgC4LjVR+kfIjVdq4q3LA7ijcc0HgPyRllTYEQBwE7R8AAAAU5F8AAAAU5F8FENRUVGKjo62z4eFhWnOnDkFXu/OnTtVt25deXt7q3v37gVen7vaunWrLBaLLl++XNihAECh4JqPO8DevXtNGZJ61KhRatCggTZs2GAfDhsAgJvR8nEHqFChgvz9/Qu8nhMnTqhdu3aqXLmySpcunWW9YRiy2WwFHgcAoGhz/+TDMG7c2lcYr1w8ky8qKkojR45UdHS0ypQpo6CgIC1YsECJiYkaOHCgSpYsqapVq2Z5/Pzhw4f1wAMPKCAgQEFBQerXr59+++03+/rExEQ9/vjjCggIUEhIiGbNmpWl7pu7XWbPnq26deuqRIkSCg0N1bBhw3Tt2jX7+iVLlqh06dLatGmTIiMjFRAQoE6dOuns2bPZ7tvJkydlsVh08eJFDRo0SBaLRUuWLLF3L2zatEmNGzeW1WrVV199pZSUFD3zzDOqWLGifH191apVK+3du9e+vT+/r2HDhvLz81O7du10/vx5bdiwQZGRkSpVqpQeeeQRJSXlfIfFqVOn1LVrV5UpU0YlSpRQ7dq1tX79eklSenq6Bg8erPDwcPn5+SkiIkJz5851eP+AAQPUvXt3TZkyRUFBQSpdurQmTpwom82m0aNHq2zZsqpcubLef//9LMdixYoVatGihXx9fVW7dm1t3bo1xzgladeuXWrdurX8/PwUGhqqZ555RomJbnTLqsVDqtLqxsvi/qcVAAXL/btd0pL+eEKm2W7jiZx/tnTpUo0ZM0bffPONVq5cqaefflqfffaZevToofHjx+uNN95Qv379dPr0afn7++vs2bNq06aNhgwZotmzZ+v69esaO3asevfurS+//FKSNHr0aMXFxWnt2rUKDg7W+PHjtX//fjVo0CDHODw8PPTmm28qLCxM8fHxGjZsmMaMGaN33nnHXiYpKUmvv/66PvjgA3l4eOixxx7TCy+8oI8++ijL9kJDQ3X27FlFRERo0qRJ6tOnjwIDA/X1119LksaMGaPXX39dd999t0qXLq0xY8Zo9erVWrp0qapUqaIZM2aoY8eOOn78uMqWLWvfbkxMjObNmyd/f3/17t1bvXv3ltVq1fLly3Xt2jX16NFDb731lsaOHZvtfg4fPlypqanavn27SpQoocOHD9u7gzIyMlS5cmWtWrVK5cuX165du/Tkk08qJCREvXv3tm/jyy+/VOXKlbV9+3bt3LlTgwcP1u7du9W6dWt9/fXXWrlypYYOHar27dsrNDTU/r7Ro0drzpw5qlWrlmbPnq2//e1vio+PV7ly5bLEeejQIXXs2FGTJ0/WokWLdOHCBY0YMUIjRozQ4sWLc/wcixRvP2lgwTz1FUDxw08UE9WvX18vv/yyqlevrnHjxsnPz0/ly5fXkCFDVL16db3yyiu6ePGivvvuO0lSbGysGjVqpClTpqhmzZpq2LCh3n//fcXFxemnn37StWvXtGjRIr3++utq37696tatq6VLlyo9Pd1pHNHR0Wrbtq3Cw8PVrl07TZ48WatWrXIok5aWpvnz56tx48Zq1KiRRowYoS+++CLb7Xl6eio4OFgWi0WBgYEKDg6Wn5+fff2kSZPUvn17Va1aVb6+voqNjdXMmTPVuXNn1apVSwsXLpSfn58WLVrksN3XXntNLVu2VMOGDTV48GBt27ZNsbGxatiwoe6991716tVLcXFxOe7n6dOn1bJlS9WtW1d33323unTpotatW0uSvL29NXHiRDVp0kTh4eF69NFHNWDAgCzHoWzZsnrzzTcVERGhQYMGKSIiQklJSRo/frz9c/Tx8dHOnTsd3jdixAg99NBDioyMVGxsrAIDA7PsX6aZM2eqb9++io6OVvXq1dWiRQu9+eabWrZsmZKTk3PcPwBwV+7f8uHtf6MForDqzoV69erZpz09PVWuXDnVrVvXviwoKEiSdP78eUnS/v37FRcXl+3FmydOnND169eVmpqq5s2b25eXLVtWERERTuOIi4vTlClTdPjwYSUkJMhmsyk5OVmJiYn2C1P9/f1VtWpV+3tCQkLsceVW48aNHeJOS0tTy5Yt7cu8vb3117/+VUeOHHF435+PV1BQkPz9/XX33Xc7LPvmm29yrPeZZ57R008/rc2bN+v+++/XQw895LDN+fPn67333tOpU6fsx/LmFqPatWvLw+OPHD0oKEh16tSxz2d+jjcfmz9/Jl5eXmrcuHGW/cu0f/9+HT9+3KFVyTAMZWRkKD4+XpGRkTnuIwC4I/dPPiyWXHV9FCZvb2+HeYvF4rDMYrFIutElkPlv165dNX369CzbCgkJ0bFjx3Idw6lTp/TAAw9o6NChmjx5ssqWLasdO3Zo8ODBSktLcxqrkYtrXP7sz3faZG4jc1//vPzmZTcfm+xiyjxW2XniiSfUsWNHrVu3Tps3b9bUqVM1a9YsjRw5UqtWrdJzzz2nWbNmqXnz5ipZsqRmzpxp7yrKLoa8xvHnctnJyMjQU089pWeeeSbLurvuuuuW2y0SUhOlOf9LpKMPuc3/SQCFg26XIqxRo0b64YcfFBYWpmrVqjm8SpQooWrVqsnb21t79uyxv+fSpUv66aefctzmvn37ZLPZNGvWLDVr1kw1atTQr7+a13JUrVo1+fj4aMeOHfZlaWlp2rdvX4H8wg8NDdXQoUO1Zs0aPf/881q4cKEk6auvvlKLFi00bNgwNWzYUNWqVdOJEyfyrd4/fyY2m0379+9XzZo1sy2b+Tnf/BlnHiu3kXTxxgsAboHkowgbPny4fv/9dz3yyCP65ptv9PPPP2vz5s0aNGiQ0tPTFRAQoMGDB2v06NH64osv9P3332vAgAEO3QQ3q1q1qmw2m9566y39/PPP+uCDDzR//nzT9qlEiRJ6+umnNXr0aG3cuFGHDx/WkCFDlJSUpMGDB+drXdHR0dq0aZPi4+P17bff6ssvv7QnONWqVdO+ffu0adMm/fTTT5owYYLDHTeuevvtt7V27Vr9+OOPGj58uC5duqRBgwZlW3bs2LHavXu3hg8froMHD+rYsWP6/PPPNXLkyHyLBwCKEpKPIqxSpUrauXOn0tPT1bFjR9WpU0fPPvusAgMD7QnGzJkz1bp1a/3tb3/T/fffr1atWumee+7JcZsNGjTQ7NmzNX36dNWpU0cfffSRpk6datYuSZKmTZumhx56SP369VOjRo10/Phxbdq0SWXKlMnXetLT0zV8+HBFRkaqU6dOioiIsN/RM3ToUPXs2VN9+vRR06ZNdfHiRQ0bNizf6p42bZqmT5+u+vXr66uvvtI///lPlS9fPtuy9erV07Zt23Ts2DHde++9atiwoSZMmKCQkJB8iwcAihKLkdeO/AKSkJCgwMBAXblyRaVKlXJYl5ycrPj4eIWHh8vX17eQIgRydvLkSYWHh+vAgQNOb3d2RZH8f5Ca+Mct77e6BT03ZXVjLJvMi66vXbtmymi92Ql7sWBuJT457cEC2S5gNmd/v29GywcAADAVyQcAADCV+99qCxQhYWFheb4l2a1ZPKRKDf+YBgAnSD4AuM7bT3pya2FHAcBN8BMFAACYiuQDAACYiuQDgOtSk6Q36t54pSYVdjQAijiu+QCQDwzpyuk/pgHACZIPAMVGQQ0EVpAKMmYGMENRRbcLsnXu3Dm1b99eJUqUUOnSpQs7nCLNYrHos88+K+wwAMBt0PKBbL3xxhs6e/asDh48qMDAwMIOBwBQjJB8IFsnTpzQPffco+rVq+dYJi0tTd7e3iZGBQAoDopPt0tqYs6vtORclL1+e2VzKSoqSiNHjlR0dLTKlCmjoKAgLViwQImJiRo4cKBKliypqlWrasOGDQ7vO3z4sB544AEFBAQoKChI/fr102+//WZfv3HjRrVq1UqlS5dWuXLl1KVLF504ccK+/uTJk7JYLFqzZo3atm0rf39/1a9fX7t3784x1rCwMK1evVrLli2TxWLRgAEDJN3oXpg/f766deumEiVK6LXXXpMkxcbGqmrVqvLx8VFERIQ++OADh+1ZLBa9++676tKli/z9/RUZGandu3fr+PHjioqKUokSJdS8eXOHuG+WmpqqESNGKCQkRL6+vgoLC3N4Gu/s2bNVt25dlShRQqGhoRo2bJiuXbtmX79kyRKVLl1a//d//6eIiAj5+/urV69eSkxM1NKlSxUWFqYyZcpo5MiRSk9PdzgWkydPVt++fRUQEKBKlSrprbfeyjFOSfrll1/Up08flSlTRuXKlVO3bt108uRJp+8BgDtJ8Uk+plTK+bWqn2PZmdVyLvthL8eyc+pmXy4Pli5dqvLly+ubb77RyJEj9fTTT+vhhx9WixYt9O2336pjx47q16+fkpJu3Kp49uxZtWnTRg0aNNC+ffu0ceNG/fe//1Xv3r3t20xMTNSoUaO0d+9effHFF/Lw8FCPHj2UkZHhUPdLL72kF154QQcPHlSNGjX0yCOPyGazZRvn3r171alTJ/Xu3Vtnz57V3Llz7eteffVVdevWTYcOHdKgQYO0du1aPfvss3r++ef1/fff66mnntLAgQMVFxfnsM3Jkyfr8ccf18GDB1WzZk317dtXTz31lMaNG6d9+/ZJkkaMGJHjsXvzzTf1+eefa9WqVTp69Kg+/PBDhYWF2dd7eHjozTff1Pfff6+lS5fqyy+/1JgxYxy2kZSUpDfffFMrVqzQxo0btXXrVvXs2VPr16/X+vXr9cEHH2jBggX69NNPHd43c+ZM1atXT99++63GjRun5557Tlu2bMk2zqSkJLVt21YBAQHavn27duzYoYCAAHXq1Empqak57p/7s0gVat54yVLYwQAo4uh2MVH9+vX18ssvS5LGjRunadOmqXz58hoyZIgk6ZVXXlFsbKy+++47NWvWTLGxsWrUqJGmTJli38b777+v0NBQ/fTTT6pRo4YeeughhzoWLVqkihUr6vDhw6pTp459+QsvvKAHH7xx5fvEiRNVu3ZtHT9+XDVr1swSZ4UKFWS1WuXn56fg4GCHdX379tWgQYMc5gcMGKBhw4ZJkkaNGqU9e/bo9ddfV9u2be3lBg4caE+axo4dq+bNm2vChAnq2LGjJOnZZ5/VwIEDczx2p0+fVvXq1dWqVStZLBZVqVLFYX10dLR9Ojw8XJMnT9bTTz+td955x748LS3N3kojSb169dIHH3yg//73vwoICFCtWrXUtm1bxcXFqU+fPvb3tWzZUi+++KIkqUaNGtq5c6feeOMNtW/fPkucK1askIeHh9577z1ZLDf+CC9evFilS5fW1q1b1aFDhxz30a35+EvDvy7sKAC4ieKTfIz/Ned1Fk/H+dHHnZS9qTEo+lDeY7pJvXr17NOenp4qV66c6tata18WFBQkSTp//rwkaf/+/YqLi1NAQECWbZ04cUI1atTQiRMnNGHCBO3Zs0e//fabvcXj9OnTDsnHn+sOCQmx15Nd8uFM48aNHeaPHDmiJ5980mFZy5YtHVpLbq4/cz9v3vfk5GQlJCSoVKlSWeodMGCA2rdvr4iICHXq1EldunRx+EMeFxenKVOm6PDhw0pISJDNZlNycrISExNVokQJSZK/v7898cisMywszOH4BgUF2Y9/pubNm2eZnzNnTtaDoxuf2fHjx1WyZEmH5cnJyU67lQDgTpKr5GPq1Klas2aNfvzxR/n5+alFixaaPn26IiIi7GUGDBigpUuXOryvadOm2rNnT/5EnBOfEoVf9hZuvjjTYrE4LMv8pZyZQGRkZKhr166aPn16lm1lJhBdu3ZVaGioFi5cqEqVKikjI0N16tTJ0sTvrJ7cyPxDfvN+/JlhGFmWZVd/bmJq1KiR4uPjtWHDBv3rX/9S7969df/99+vTTz/VqVOn9MADD2jo0KGaPHmyypYtqx07dmjw4MFKS0vLNobMOrNbdjvH5eb9y5SRkaF77rlHH330UZZ1FSpUuOV2AeBOkKvkY9u2bRo+fLiaNGkim82ml156SR06dNDhw4cd/ih16tRJixcvts/7+PjkX8R3kEaNGmn16tUKCwuTl1fWj+rixYs6cuSI3n33Xd17772SpB07dpgaY2RkpHbs2KHHH3/cvmzXrl2KjIzM97pKlSqlPn36qE+fPurVq5c6deqk33//Xfv27ZPNZtOsWbPk4XGj5WrVqlX5Vu/NifOePXtybDFq1KiRVq5cqYoVK2bbglNspSZJC//XzTYk7kY3DADkIFfJx8aNGx3mFy9erIoVK2r//v1q3bq1fbnVas1yrQByb/jw4Vq4cKEeeeQRjR49WuXLl9fx48e1YsUKLVy40H43xYIFCxQSEqLTp0/br00wy+jRo9W7d281atRI9913n/7f//t/WrNmjf71r3/laz1vvPGGQkJC1KBBA3l4eOiTTz5RcHCwSpcurapVq8pms+mtt95S165dtXPnTs2fPz/f6t65c6dmzJih7t27a8uWLfrkk0+0bl32o1I++uijmjlzprp166ZJkyapcuXKOn36tNasWaPRo0ercuXK+RZX0WJIF378YxoAnHDpbpcrV65IksqWLeuwfOvWrapYsaJq1KihIUOGZOlD/7OUlBQlJCQ4vHBDpUqVtHPnTqWnp6tjx46qU6eOnn32WQUGBsrDw0MeHh5asWKF9u/frzp16ui5557TzJkzTY2xe/fumjt3rmbOnKnatWvr3Xff1eLFixUVFZWv9QQEBGj69Olq3LixmjRpopMnT2r9+vXy8PBQgwYNNHv2bE2fPl116tTRRx995HAbrquef/557d+/Xw0bNtTkyZM1a9Ys+4WyN/P399f27dt11113qWfPnoqMjNSgQYN0/fr1O6slBACcsBiGkaefKYZhqFu3brp06ZK++uor+/KVK1cqICBAVapUUXx8vCZMmCCbzab9+/fLarVm2U5MTIwmTpyYZfmVK1eynKyTk5MVHx+v8PBw+fr65iVsIFfCwsIUHR3tcDdNYSuS/w9SE/+4BX38r86vlcpNWd24nTzzouBr165le91RJnd8tos74pkxyE5CQoICAwOz/ft9szzf7TJixAh99913Wa4x+PMtinXq1FHjxo1VpUoVrVu3Tj179syynXHjxmnUqFEOwYeGhuY1LAAAUMTlKfkYOXKkPv/8c23fvv2WfdghISGqUqWKjh07lu16q9WabYsIAAAonnKVfBiGoZEjR2rt2rXaunWrwsPDb/meixcv6syZM/ZbQwF3wrDoAJD/cnXB6fDhw/Xhhx9q+fLlKlmypM6dO6dz587p+vUbz0O5du2aXnjhBe3evVsnT57U1q1b1bVrV5UvX149evQokB0AUBRYpMC7brwYXh3ALeSq5SM2NlaSstzJsHjxYg0YMECenp46dOiQli1bpsuXLyskJERt27bVypUrs4z46Io8XiMLFAtF8vvv4y89l3+jAQMo3nLd7eKMn5+fNm3a5FJAzmSORpmUlCQ/P78CqwcoyjJHr/X09LxFSQAomtzq2S6enp4qXbq0fdwQf3//HIe5BoqjjIwMXbhwQf7+/tmOegsA7sDtzl6ZI6c6G7gMKM48PDx01113Fa3EO+26tLjzjemBGyRvWiYB5Mztkg+LxaKQkBBVrFjR4aFhwJ3Cx8fH/gybIsPIkH498Mc0ADjhdslHJk9PT/q8AQBwQ0Xs5xMAACju3LblA0DBys1zUvyUrCP/e8xM5CsbdV05P3Pm5KQoFyMD4O5o+QAAAKYi+QAAAKai2wVAvrho5N8oxgCKN5IPAC67Ll/dk/JuYYcBwE3Q7QIAAExF8gEAAExF8gHAZValaoXPZK3wmSyrUgs7HABFHNd8AHCZhzLUzOOIfRoAnKHlAwAAmIrkAwAAmIrkAwAAmIprPgA3lpvnrwBAUUHLBwAAMBUtHwDyRZJhLewQALgJkg8ALrsuX9VKWVzYYQBwE3S7AAAAU5F8AAAAU5F8AHCZVal633uG3veewfDqAG6Jaz4AuMxDGWrnefDGdBrDqwNwjpYPAABgKpIPAABgKpIPAABgKpIPAABgKpIPAABgKpIPAABgKm61BeCy6/JVWPLywg4DgJug5QMAAJiK5AMAAJiK5AOAy6xK1dvec/S29xyGVwdwSyQfAFzmoQw96PmNHvT8Rh5ieHUAzpF8AAAAU5F8AAAAU5F8AAAAU5F8AAAAU5F8AAAAU5F8AAAAUzG8OgCXXZdVkcnv26cBwBmSDwD5wKLr8i3sIAC4CbpdAACAqUg+ALjMR2l63Xu+XveeLx+lFXY4AIo4kg8ALvNUunp5blcvz+3yVHphhwOgiCP5AAAApiL5AAAApiL5AAAApspV8jF16lQ1adJEJUuWVMWKFdW9e3cdPXrUoYxhGIqJiVGlSpXk5+enqKgo/fDDD/kaNAAAcF+5Sj62bdum4cOHa8+ePdqyZYtsNps6dOigxMREe5kZM2Zo9uzZmjdvnvbu3avg4GC1b99eV69ezffgAQCA+8nVIGMbN250mF+8eLEqVqyo/fv3q3Xr1jIMQ3PmzNFLL72knj17SpKWLl2qoKAgLV++XE899VT+RQ4AANySS9d8XLlyRZJUtmxZSVJ8fLzOnTunDh062MtYrVa1adNGu3btynYbKSkpSkhIcHgBcC/XZVWj5PlqlDyf4dUB3FKeh1c3DEOjRo1Sq1atVKdOHUnSuXPnJElBQUEOZYOCgnTq1KlstzN16lRNnDgxr2EAKBIs+l2lbqtk5CsbdcT3j+lbDcuekZr8x3snbJSHD8O4A+4uzy0fI0aM0HfffaePP/44yzqLxeIwbxhGlmWZxo0bpytXrthfZ86cyWtIAADADeSp5WPkyJH6/PPPtX37dlWuXNm+PDg4WNKNFpCQkBD78vPnz2dpDclktVpltdJMC7gzH6XpZa8PJUmv2R5TqrwLOSIARVmuWj4Mw9CIESO0Zs0affnllwoPD3dYHx4eruDgYG3ZssW+LDU1Vdu2bVOLFi3yJ2IARY6n0vW41xY97rWF4dUB3FKuWj6GDx+u5cuX65///KdKlixpv8YjMDBQfn5+slgsio6O1pQpU1S9enVVr15dU6ZMkb+/v/r27VsgOwAAANxLrpKP2NhYSVJUVJTD8sWLF2vAgAGSpDFjxuj69esaNmyYLl26pKZNm2rz5s0qWbJkvgQMAADcW66SD8MwblnGYrEoJiZGMTExeY0JAAAUYzzbBQAAmIrkAwAAmIrkAwAAmCrPI5wCQKZk+ahVylz7NAA4Q/IBwGWGPPQfo0JhhwHATdDtAgAATEXLBwCXecumF7xWSpJet/VRGqcWAE7Q8gHAZV6y6SmvdXrKa528ZCvscAAUcSQfAADAVCQfAADAVCQfAADAVCQfAADAVCQfAADAVCQfAADAVNyMD8BlyfJR+5QZ9mkAcIbkA4DLDHnomFG5sMMA4CbodgEAAKai5QP4n7AX1xXYtk9Oe7DAtl0UeMum4V6fSZLetnVneHUATnGGAOAyL9kU7bVGkvSurQvJBwCn6HYBAACmIvkAAACmIvkAAACmIvkAAACmIvkAAACmIvkAAACm4n44AC5LkY/+ljLZPg0AzpB8AHBZhjz0nVG1sMMA4CbodgEAAKai5QOAy7xl00DPDZKkxemdGeEUgFOcIeB2CvIZLMgbL9k03vtjSdIH6e1JPgA4RbcLAAAwFckHAAAwFckHAAAwFckHAAAwFckHAAAwFckHAAAwFffDAXBZinz099SX7dMA4AzJBwCXZchDezJqFXYYANwE3S4AAMBUtHwAcJmXbHrE80tJ0sfp7WTj1ALACc4QAFzmLZsmey+RJH2a3prkA4BTnCFQIHj+ClB8FeT/75PTHiywbaPo4JoPAABgKpIPAABgKpIPAABgKpIPAABgKpIPAABgKu52AeCyVHlrYOpo+zQAOEPyAcBl6fJUXEbDwg4DgJvIdbfL9u3b1bVrV1WqVEkWi0WfffaZw/oBAwbIYrE4vJo1a5Zf8QIAADeX6+QjMTFR9evX17x583Is06lTJ509e9b+Wr9+vUtBAijavGRTL89t6uW5TV6yFXY4AIq4XHe7dO7cWZ07d3Zaxmq1Kjg4OM9BAXAv3rLpde93JUnr0psyvDoApwrkbpetW7eqYsWKqlGjhoYMGaLz58/nWDYlJUUJCQkOLwAAUHzl+8+Tzp076+GHH1aVKlUUHx+vCRMmqF27dtq/f7+sVmuW8lOnTtXEiRPzO4wc8UwCRzyDBQBgtnxPPvr06WOfrlOnjho3bqwqVapo3bp16tmzZ5by48aN06hRo+zzCQkJCg0Nze+wAABAEVHgHbMhISGqUqWKjh07lu16q9WabYsIAAAongp8hNOLFy/qzJkzCgkJKeiqAACAG8h1y8e1a9d0/Phx+3x8fLwOHjyosmXLqmzZsoqJidFDDz2kkJAQnTx5UuPHj1f58uXVo0ePfA0cAAC4p1wnH/v27VPbtm3t85nXa/Tv31+xsbE6dOiQli1bpsuXLyskJERt27bVypUrVbJkyfyLGkCRkipvDUt9xj4NAM7kOvmIioqSYRg5rt+0aZNLAQFwP+ny1PoMRjIGcHt4qi0AADAVwxACcJmn0tXRY68kaVNGE6XLs5AjAlCUkXwAcJmP0vSOz5uSpMjk93Wd5AOAE3S7AAAAU5F8AAAAU9HtApiAZ+gAwB9o+QAAAKYi+QAAAKYi+QAAAKbimg8ALkuTl15Ie8o+DQDOcJYA4DKbvPRpepvCDgOAm6DbBQAAmIqWDwAu81S6Wnt8J0nanlGP4dUBOEXyAcBlPkrTYp+ZkhheHcCt0e0CAABMRfIBAABMRfIBAABMRfIBAABMRfIBAABMRfIBAABMxa22AFyWJi9NSBtgnwYAZzhLAHCZTV76IL1DYYcBwE3Q7QIAAExFywcAl3koQ3/1+FGS9E1GTWXwuwaAEyQfAFxmVapW+LwmKXN4dd9CjghAUcbPEwAAYCqSDwAAYCqSDwAAYCqSDwAAYCqSDwAAYCqSDwAAYCputQXgMpu8NCXtEfs0ADjDWQKAy9LkpQXpXQs7DABugm4XAABgKlo+ALjMQxmqY4mXJH1vhDO8OgCnSD4AuMyqVH1unSCJ4dUB3Bo/TwAAgKlIPgAAgKlIPgAAgKlIPgAAgKlIPgAAgKlIPgAAgKm41RaAy2zy0hxbT/s0ADjDWQKAy9LkpTm2XoUdBgA3QbcLAAAwFS0fAFxmUYaqWX6VJB03Ksngdw0AJ0g+ALjMV6naYh0jieHVAdwaP08AAICpSD4AAICpSD4AAICpcp18bN++XV27dlWlSpVksVj02WefOaw3DEMxMTGqVKmS/Pz8FBUVpR9++CG/4gUAAG4u18lHYmKi6tevr3nz5mW7fsaMGZo9e7bmzZunvXv3Kjg4WO3bt9fVq1ddDhYAALi/XN/t0rlzZ3Xu3DnbdYZhaM6cOXrppZfUs+eN0Q6XLl2qoKAgLV++XE899ZRr0QIAALeXr9d8xMfH69y5c+rQoYN9mdVqVZs2bbRr165s35OSkqKEhASHFwD3YpOX3rU9qHdtDzK8OoBbytezxLlz5yRJQUFBDsuDgoJ06tSpbN8zdepUTZw4MT/DKHbCXlxX2CEATqXJS1NtjxZ2GADcRIHc7WKxWBzmDcPIsizTuHHjdOXKFfvrzJkzBRESAAAoIvK15SM4OFjSjRaQkJAQ+/Lz589naQ3JZLVaZbVa8zMMACazKEN/sVyUJP1ilGN4dQBO5esZIjw8XMHBwdqyZYt9WWpqqrZt26YWLVrkZ1UAihBfpWqH9VntsD4rX6UWdjgAirhct3xcu3ZNx48ft8/Hx8fr4MGDKlu2rO666y5FR0drypQpql69uqpXr64pU6bI399fffv2zdfAAQCAe8p18rFv3z61bdvWPj9q1ChJUv/+/bVkyRKNGTNG169f17Bhw3Tp0iU1bdpUmzdvVsmSJfMvagAA4LZynXxERUXJMIwc11ssFsXExCgmJsaVuAAAQDHFVWEAAMBUJB8AAMBUJB8AAMBUjIMMwGXp8tQyW3v7NAA4Q/IBwGWp8tYrtoGFHQYAN0HyAQAo9gryGVknpz1YYNsurkg+AOQDQ2V1VZL0u0pKyv5ZTgAgkXwAyAd+StG3vkMlSZHJ7+u6fAs5IgBFGXe7AAAAU5F8AAAAU5F8AAAAU5F8AAAAU5F8AAAAU5F8AAAAU3GrLQCXpctTn6a3tk8DgDMkHwBclipvvZA2tLDDAOAm6HYBAACmouUDQD4w5KcUSdJ1WcXw6gCcoeUDgMv8lKIjvoN0xHeQPQkBgJyQfAAAAFORfAAAAFORfAAAAFORfAAAAFORfAAAAFORfAAAAFMxzgcAl2XIQ+vS/2qfBgBnSD4AuCxFPhqeFl3YYQBwE/xEAQAApiL5AAAApqLbJR+FvbiusEMACoWfknXEd5AkKTL5fV2XbyFHBKAoo+UDAACYiuQDAACYiuQDAACYiuQDAACYiuQDAACYiuQDAACYilttAbgsQx76Mr2BfRoAnCH5AOCyFPloUNqYwg4DgJvgJwoAADAVyQcAADAVyQcAl/kpWYetA3XYOlB+Si7scAAUcVzzASBf+FtSCjsEAG6Clg8AAGAqkg8AAGAqkg8AAGAqkg8AAGAqkg8AAGAq7nYB4LIMeWhPRqR9GgCcIfkA4LIU+ejvqRMKOwwAboKfKAAAwFT5nnzExMTIYrE4vIKDg/O7GgAA4KYKpNuldu3a+te//mWf9/T0LIhqABQRfkrWDuuzkqRWKXN1Xb6FHBGAoqxAkg8vLy9aO4A7TDnL1cIOAYCbKJBrPo4dO6ZKlSopPDxcf//73/Xzzz/nWDYlJUUJCQkOLwAAUHzle/LRtGlTLVu2TJs2bdLChQt17tw5tWjRQhcvXsy2/NSpUxUYGGh/hYaG5ndIAACgCMn35KNz58566KGHVLduXd1///1at26dJGnp0qXZlh83bpyuXLlif505cya/QwIAAEVIgY/zUaJECdWtW1fHjh3Ldr3VapXVai3oMAAAQBFR4ON8pKSk6MiRIwoJCSnoqgAAgBvI95aPF154QV27dtVdd92l8+fP67XXXlNCQoL69++f31UBKCIy5KF/Z9xtnwYAZ/I9+fjPf/6jRx55RL/99psqVKigZs2aac+ePapSpUp+VwWgiEiRj7qlvlbYYQBwE/mefKxYsSK/NwkAAIoR2kcBAICpSD4AuMxXKdphfUY7rM/IVymFHQ6AIq7Ab7UFUPxZZKiy5Tf7NAA4Q8sHAAAwFckHAAAwFd0uAIAiI+zFdYUdQq4VVMwnpz1YINstCmj5AAAApiL5AAAApqLbBYDLDFn0U8Zf7NMA4AzJBwCXJcuqDqkzCzsMAG6CbhcAAGAqkg8AAGAqkg8ALvNVijb7jNZmn9EMrw7glrjmA4DLLDJUw+MX+zQAOEPLBwAAMBXJBwAAMBXJBwAAMBXJBwAAMBXJBwAAMBV3uwBwmSGL/mOUt08DgDMkHwBcliyrWqW8WdhhAHATdLsAAABTkXwAAABTkXwAcJlVqfqnz8v6p8/Lsiq1sMMBUMRxzQcAl3koQ/U9frZPA4AztHwAAABTkXwAAABTkXwAAABTkXwAAABTccEpAABFUNiL6wps2yenPVhg274dJB8A8sVFo2RhhwDATZB8AHDZdfnqnpR3CzsMAG6Caz4AAICpSD4AAICpSD4AuMyqVK3wmawVPpMZXh3ALXHNBwCXeShDzTyO2KcBwBlaPgAAgKlIPgAAgKlIPgAAgKlIPgAAgKlIPgAAgKm42wVAvkgyrIUdAgA3QfIBwGXX5ataKYsLOwwAboJuFwAAYCqSDwAAYCqSDwAusypV73vP0PveMxheHcAtcc0HAJd5KEPtPA/emE5jeHUAztHyAQAATEXyAQAATFVgycc777yj8PBw+fr66p577tFXX31VUFUBAAA3UiDJx8qVKxUdHa2XXnpJBw4c0L333qvOnTvr9OnTBVEdAABwIwWSfMyePVuDBw/WE088ocjISM2ZM0ehoaGKjY0tiOoAAIAbyfe7XVJTU7V//369+OKLDss7dOigXbt2ZSmfkpKilJQU+/yVK1ckSQkJCfkdmiQpIyWpQLYL3MnSlawEi3FjOiVJGcr5jpfclJWkjNTkP6ZTkiSDu2kAVxXE39jMbRqGccuy+Z58/Pbbb0pPT1dQUJDD8qCgIJ07dy5L+alTp2rixIlZloeGhuZ3aAAKUKB96vF8Lftnv7yTu/IAshc4p+C2ffXqVQUGBjotU2DjfFgsFod5wzCyLJOkcePGadSoUfb5jIwM/f777ypXrly25YuyhIQEhYaG6syZMypVqlRhh2O6O33/JY7Bnb7/EsfgTt9/6c49BoZh6OrVq6pUqdIty+Z78lG+fHl5enpmaeU4f/58ltYQSbJarbJaHZ+GWbp06fwOy1SlSpW6o75wN7vT91/iGNzp+y9xDO70/ZfuzGNwqxaPTPl+wamPj4/uuecebdmyxWH5li1b1KJFi/yuDgAAuJkC6XYZNWqU+vXrp8aNG6t58+ZasGCBTp8+raFDhxZEdQAAwI0USPLRp08fXbx4UZMmTdLZs2dVp04drV+/XlWqVCmI6ooMq9WqV199NUs30p3iTt9/iWNwp++/xDG40/df4hjcDotxO/fEAAAA5BOe7QIAAExF8gEAAExF8gEAAExF8gEAAExF8gEAAExF8pGD7du3q2vXrqpUqZIsFos+++wzp+W3bt0qi8WS5fXjjz86lFu9erVq1aolq9WqWrVqae3atQW4F3mX2/0fMGBAtvtfu3Zte5klS5ZkWyY5OdnJlgvH1KlT1aRJE5UsWVIVK1ZU9+7ddfTo0Vu+b9u2bbrnnnvk6+uru+++W/Pnz89Sxl2+A3k5BmvWrFH79u1VoUIFlSpVSs2bN9emTZscyrjL9yAv+1/czgN5OQbF6VwQGxurevXq2Ucqbd68uTZs2OD0PcXpHFCQSD5ykJiYqPr162vevHm5et/Ro0d19uxZ+6t69er2dbt371afPn3Ur18//fvf/1a/fv3Uu3dvff311/kdvstyu/9z58512O8zZ86obNmyevjhhx3KlSpVyqHc2bNn5evrWxC74JJt27Zp+PDh2rNnj7Zs2SKbzaYOHTooMTExx/fEx8frgQce0L333qsDBw5o/PjxeuaZZ7R69Wp7GXf6DuTlGGzfvl3t27fX+vXrtX//frVt21Zdu3bVgQMHHMq5w/cgL/ufqbicB/JyDIrTuaBy5cqaNm2a9u3bp3379qldu3bq1q2bfvjhh2zLF7dzQIEycEuSjLVr1zotExcXZ0gyLl26lGOZ3r17G506dXJY1rFjR+Pvf/97PkRZcG5n/2+2du1aw2KxGCdPnrQvW7x4sREYGJi/wZnk/PnzhiRj27ZtOZYZM2aMUbNmTYdlTz31lNGsWTP7vLt+Bwzj9o5BdmrVqmVMnDjRPu+u34Pb2f/ifB4wjLx9B4rbuaBMmTLGe++9l+264n4OyE+0fOSzhg0bKiQkRPfdd5/i4uIc1u3evVsdOnRwWNaxY0ft2rXLzBBNsWjRIt1///1ZRrW9du2aqlSposqVK6tLly5ZfhEXVVeuXJEklS1bNscyOX2++/btU1pamtMy7vAduJ1jcLOMjAxdvXo1y3vc8XuQm/0vrueBvHwHisu5ID09XStWrFBiYqKaN2+ebZnifg7ITyQf+SQkJEQLFizQ6tWrtWbNGkVEROi+++7T9u3b7WXOnTuX5cm+QUFBWZ4A7O7Onj2rDRs26IknnnBYXrNmTS1ZskSff/65Pv74Y/n6+qply5Y6duxYIUV6ewzD0KhRo9SqVSvVqVMnx3I5fb42m02//fab0zJF/Ttwu8fgZrNmzVJiYqJ69+5tX+aO34Pb3f/ifB7Iy3egOJwLDh06pICAAFmtVg0dOlRr165VrVq1si1bnM8B+a1Anu1yJ4qIiFBERIR9vnnz5jpz5oxef/11tW7d2r7cYrE4vM8wjCzL3N2SJUtUunRpde/e3WF5s2bN1KxZM/t8y5Yt1ahRI7311lt68803TY7y9o0YMULfffedduzYccuy2X2+Ny93x+9Abo5Bpo8//lgxMTH65z//qYoVK9qXu+P34Hb3vzifB/LyHSgO54KIiAgdPHhQly9f1urVq9W/f39t27YtxwSkuJ4D8hstHwWoWbNmDpl8cHBwluz2/PnzWbJgd2YYht5//33169dPPj4+Tst6eHioSZMmRfLXTqaRI0fq888/V1xcnCpXruy0bE6fr5eXl8qVK+e0TFH+DuTmGGRauXKlBg8erFWrVun+++93Wraofw/ysv9/VhzOA3k5BsXlXODj46Nq1aqpcePGmjp1qurXr6+5c+dmW7a4ngMKAslHATpw4IBCQkLs882bN9eWLVscymzevFktWrQwO7QCs23bNh0/flyDBw++ZVnDMHTw4EGHY1RUGIahESNGaM2aNfryyy8VHh5+y/fk9Pk2btxY3t7eTssUxe9AXo6BdKPFY8CAAVq+fLkefPDB26qnKH4P8rr/N3Pn84Arx6C4nAtuZhiGUlJSsl1X3M4BBcrc61vdx9WrV40DBw4YBw4cMCQZs2fPNg4cOGCcOnXKMAzDePHFF41+/frZy7/xxhvG2rVrjZ9++sn4/vvvjRdffNGQZKxevdpeZufOnYanp6cxbdo048iRI8a0adMMLy8vY8+ePabv363kdv8zPfbYY0bTpk2z3WZMTIyxceNG48SJE8aBAweMgQMHGl5eXsbXX39doPuSF08//bQRGBhobN261Th79qz9lZSUZC9z8zH4+eefDX9/f+O5554zDh8+bCxatMjw9vY2Pv30U3sZd/oO5OUYLF++3PDy8jLefvtth/dcvnzZXsZdvgd52f/idh7IyzHIVBzOBePGjTO2b99uxMfHG999950xfvx4w8PDw9i8ebNhGMX/HFCQSD5ykHnL3M2v/v37G4ZhGP379zfatGljLz99+nSjatWqhq+vr1GmTBmjVatWxrp167Js95NPPjEiIiIMb29vo2bNmg4npaIkt/tvGIZx+fJlw8/Pz1iwYEG224yOjjbuuusuw8fHx6hQoYLRoUMHY9euXQW8J3mT3b5LMhYvXmwvk90x2Lp1q9GwYUPDx8fHCAsLM2JjY7Ns212+A3k5Bm3atHH6vTEM9/ke5GX/i9t5IK//D4rLuWDQoEFGlSpV7HHed9999sTDMIr/OaAgWQzjf1fDAAAAmIBrPgAAgKlIPgAAgKlIPgAAgKlIPgAAgKlIPgAAgKlIPgAAgKlIPgAAgKlIPgAAgKlIPgAAgKlIPgAAgKlIPgAAgKn+P2ttR3Iw/6M0AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAikAAAGxCAYAAACnTiatAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA/TklEQVR4nO3deZyNdf/H8feZ7cyMGYNhtkxmsg5jH79sMcgWbpK4U8pyiyw1yRIt98idCZGkpiiidKu76O5OtsoSpVB+iNs6aCE3yTDMfv3+8HPujjkjhzPnXDPn9Xw8zqPrXOvn+rqmec/32iyGYRgCAAAwGR9PFwAAAOAIIQUAAJgSIQUAAJgSIQUAAJgSIQUAAJgSIQUAAJgSIQUAAJgSIQUAAJgSIQUAAJgSIQWAR8TFxWngwIG27z///LNSU1O1Y8eO61rfd999p7Zt2yosLEwWi0WzZ892SZ0APMfP0wUAgHQppEyePFlxcXFq1KiR08sPHjxYWVlZWrp0qSpWrKi4uDiX1wjAvQgpAMqE3bt3a+jQoerataunSwHgIpzuAWAnNTVVFotFO3fu1N13362wsDBVqlRJY8aMUX5+vvbt26cuXbooNDRUcXFxmj59ut3ymZmZGjt2rOLj4xUQEKCbbrpJKSkpysrKKnab69evV7NmzSRJgwYNksVikcViUWpq6h/W++abb8pisSg/P1/p6em2ZQGUfvSkAHCob9++uu+++zRs2DCtXbtW06dPV15enj799FONGDFCY8eO1TvvvKMJEyaoRo0a6t27ty5cuKC2bdvqxx9/1KRJk9SgQQN9//33evrpp7Vr1y59+umnDgNEkyZNtHDhQg0aNEhPPvmkunXrJkmqWrXqH9bZrVs3ffXVV2rRooX69Omjxx57zOVtAcAzCCkAHHrwwQc1ZswYSdLtt9+uNWvWaO7cuVq2bJnuvPNOSVJycrI+/vhjLVmyRL1799acOXO0c+dOff3110pKSpIkdejQQTfddJP69OmjVatWOTwdU758eSUmJkqSqlevrubNm19znVWqVFGVKlUkSZGRkU4tC8DcON0DwKHu3bvbfU9ISJDFYrELGX5+fqpRo4aOHj0qSfr444+VmJioRo0aKT8/3/bp3LmzLBaL1q9f785dAFDK0ZMCwKFKlSrZfQ8ICFBwcLACAwOLjM/MzJQk/fLLLzp48KD8/f0drvPUqVMlUyyAMomQAsBlKleurKCgIC1YsKDY6QBwrQgpAFyme/fumjp1qsLDwxUfH+/UslarVZJ08eLFkigNQClESAHgMikpKfrggw/Upk0bPfroo2rQoIEKCwt17NgxrVmzRo899phuvfVWh8tWr15dQUFBWrJkiRISEhQSEqKYmBjFxMS4eS8AmAUXzgJwmXLlyumLL77QwIEDNW/ePHXr1k19+/bVnDlzVLVq1as+BTY4OFgLFizQ6dOn1alTJzVr1kzz5s1zX/EATMdiGIbh6SIAAACuRE8KAAAwJa5JAWBahmGooKDgqvP4+vryGHygjKInBYBpbdiwQf7+/lf9LFq0yNNlAighXJMCwLTOnTunffv2XXWe+Ph4hYeHu6kiAO5ESAEAAKbE6R4AAGBKprtwtrCwUD///LNCQ0O5GA4AgFLCMAydO3dOMTEx8vFxTR+I6ULKzz//rNjYWE+XAQAArsMPP/ygqlWrumRdpgspoaGhki7tZPny5T1cDQBTyM2SZta+NPzYPimgnEuWzcrKsj12/+eff1a5ck6sF4CdzMxMxcbG2n6Pu4LpQsrlUzzly5cnpAC4JNdXsv7/6d/y5Z0MKcUv6+vraxsuX748IQVwAVdeqsGFswAAwJRM15MCAEX4+EkN+/93GIBX4KcdgPn5WaU70z1dBQA3K5UhxTAM5efn/+E7PYCyyN/f3+5aCgAoq0pdSMnNzdXx48d14cIFT5cCeITFYlHVqlUVEhLi6VLcxzCkvP//mfcPlniGEuAVSlVIKSwsVEZGhnx9fRUTE6OAgAAe+AavYhiG/vOf/+jHH39UzZo1vadHJe+CNPXSrcKa9LNzd/cAKLVKVUjJzc1VYWGhYmNjFRwc7OlyAI+oUqWKjhw5ory8PO8JKQC8Uqm8BdlVj9sFSiN6DwF4C37bAwAAUyKkAAAAU3IqpKSnp6tBgwa2R9a3aNFCK1eutE03DEOpqamKiYlRUFCQkpOT9f3337u8aJS8N998UxUqVPB0GQAAL+ZUSKlataqee+45bdu2Tdu2bVP79u3Vs2dPWxCZPn26Zs2apblz52rr1q2KiopSx44dde7cuRIpHvbi4uI0e/ZsT5cBAIBLOBVSevTooTvuuEO1atVSrVq19OyzzyokJERbtmyRYRiaPXu2nnjiCfXu3VuJiYlatGiRLly4oHfeeaek6oeTCgoKVFhYWCLrzsvLK5H1ArL4SnV7XvpYuKMJ8BbXfU1KQUGBli5dqqysLLVo0UIZGRk6ceKEOnXqZJvHarWqbdu2+vLLL4tdT05OjjIzM+0+zjAMQ1lZWR75GIZxzXUWFhZq2rRpqlGjhqxWq26++WY9++yztum7du1S+/btFRQUpPDwcD344IM6f/68bfrAgQPVq1cvPf/884qOjlZ4eLhGjhxpCwbJyck6evSoHn30UVksFtsdIJdP23z88ceqW7eurFarjh49qjNnzuj+++9XxYoVFRwcrK5du+rAgQPXvD9HjhyRxWLRe++9p+TkZAUGBurtt99WamqqGjVqZDfv7NmzFRcXd837AhThHyj1XXzp4x/o6WoAuInTz0nZtWuXWrRooezsbIWEhGj58uWqW7euLYhERkbazR8ZGamjR48Wu760tDRNnjzZ2TJsLly44LEnb54/f/6aX+0+ceJEzZ8/Xy+88IJat26t48eP69///rekS/vQpUsXNW/eXFu3btXJkyf1l7/8RaNGjdKbb75pW8e6desUHR2tdevW6eDBg+rXr58aNWqkoUOHatmyZWrYsKEefPBBDR061G7bFy5cUFpaml5//XWFh4crIiJC/fv314EDB/TRRx+pfPnymjBhgu644w7t2bNH/v7+19wGEyZM0MyZM7Vw4UJZrVbNmzfvmpa72r4AcI24x1eUyHqPPNetRNYLXMnpkFK7dm3t2LFDv/32mz744AM98MAD2rBhg236lc9wMAzjqs91mDhxosaMGWP7npmZqdjYWGfLMrVz587pxRdf1Ny5c/XAAw9IkqpXr67WrVtLkpYsWaKLFy9q8eLFttAzd+5c9ejRQ9OmTbMFv4oVK2ru3Lny9fVVnTp11K1bN3322WcaOnSoKlWqJF9fX4WGhioqKspu+3l5eXrllVfUsGFDSbKFk82bN6tly5a2GmJjY/Xhhx/q7rvvvuZ9S0lJUe/evZ1uk6vtCwAA0nWElICAANWoUUOSlJSUpK1bt+rFF1/UhAkTJEknTpxQdHS0bf6TJ08W6V35PavVKqvV6mwZNsHBwXanRdzpWp96u3fvXuXk5KhDhw7FTm/YsKFdr0yrVq1UWFioffv22dqvXr16dk8YjY6O1q5du/5w+wEBAWrQoIHd9vz8/HTrrbfaxoWHh6t27drau3fvNe3TZUlJSU7Nf9n17gu8VG4Wj8UHvNANPxbfMAzl5OQoPj5eUVFRWrt2rRo3bizp0mPsN2zYoGnTpt1wocWxWCzXfMrFU4KCgq46/Wq9Tb8ff+VpGIvFck0XwQYFBdmtp7hraf6o18uRK9vex8enyPodXWtyvfsCAPAeTl04O2nSJH3xxRc6cuSIdu3apSeeeELr16/XvffeK4vFopSUFE2dOlXLly/X7t27NXDgQAUHB6t///4lVX+pULNmTQUFBemzzz5zOL1u3brasWOHsrKybOM2b94sHx8f1apV65q3ExAQoIKCgj+cr27dusrPz9fXX39tG3f69Gnt379fCQkJ17w9R6pUqaITJ07YBZUdO3bc0DoBAN7JqZDyyy+/aMCAAapdu7Y6dOigr7/+WqtWrVLHjh0lSePHj1dKSopGjBihpKQk/fTTT1qzZo1CQ0NLpPjSIjAwUBMmTND48eO1ePFiHTp0SFu2bNEbb7whSbr33nsVGBioBx54QLt379a6des0evRoDRgw4Kqnyq4UFxenjRs36qefftKpU6eKna9mzZrq2bOnhg4dqk2bNul///d/dd999+mmm25Sz549b2hfk5OT9Z///EfTp0/XoUOH9PLLL9s98A8AgGvlVEh54403dOTIEeXk5OjkyZP69NNPbQFFutRln5qaquPHjys7O1sbNmxQYmKiy4sujZ566ik99thjevrpp5WQkKB+/frp5MmTki5d27J69Wr9+uuvatasmfr06aMOHTpo7ty5Tm3jmWee0ZEjR1S9enVVqVLlqvMuXLhQTZs2Vffu3dWiRQsZhqFPPvnEqTt7HElISNArr7yil19+WQ0bNtQ333yjsWPH3tA6AQDeyWI487APN8jMzFRYWJjOnj2r8uXL203Lzs5WRkaG4uPjFRjIsxLgnbzy5+BGLpy9yrJZWVm2Rxg480iB0oJbkOFOV/v9fb14wSAAADClG767BwBKnMVXqtnpv8MAvAIhBYD5+QdK9/7D01UAcDNO9wAAAFOiJwWAW5XUxZzFCVK29v7/9cUJT6/SRf33YuPC3GzbcMJTq+QTUPyFyFwsCrgfPSkATC9I2dpjHaQ91kEKUvYfLwCgTKAnBUCpEGzJ8XQJANyMnhQAAGBKhBQAAGBKhJQyKDk5WSkpKbbvcXFxmj17dolvd/Pmzapfv778/f3Vq1evEt9eabV+/XpZLBb99ttvni4FAEyNa1K8wNatW93yuO8xY8aoUaNGWrlype1R4wAAXC96UrxAlSpVFBwcXOLbOXTokNq3b6+qVauqQoUKRaYbhqH8/PwSrwMAUDaU/pBiGJdeIOaJjxPvZkxOTtbo0aOVkpKiihUrKjIyUvPmzVNWVpYGDRqk0NBQVa9eXStXrrRbbs+ePbrjjjsUEhKiyMhIDRgwQKdOnbJNz8rK0v3336+QkBBFR0dr5syZRbZ95emeWbNmqX79+ipXrpxiY2M1YsQInT9/3jb9zTffVIUKFbR69WolJCQoJCREXbp00fHjxx3u25EjR2SxWHT69GkNHjxYFotFb775pu20xurVq5WUlCSr1aovvvhCOTk5evjhhxUREaHAwEC1bt1aW7duta3v98s1btxYQUFBat++vU6ePKmVK1cqISFB5cuX1z333KMLFy4U2+ZHjx5Vjx49VLFiRZUrV0716tXTJ598IkkqKCjQkCFDFB8fr6CgINWuXVsvvvii3fIDBw5Ur169NHXqVEVGRqpChQqaPHmy8vPzNW7cOFWqVElVq1bVggULirTF0qVL1bJlSwUGBqpevXpav359sXVK0pdffqk2bdooKChIsbGxevjhh5WVlXXVZbxJoXy0pTBBWwoTVFgG/rcF4NqU/tM9eRf++4ZTd3PybayLFi3S+PHj9c033+jdd9/VQw89pA8//FB33nmnJk2apBdeeEEDBgzQsWPHFBwcrOPHj6tt27YaOnSoZs2apYsXL2rChAnq27evPv/8c0nSuHHjtG7dOi1fvlxRUVGaNGmStm/frkaNGhVbh4+Pj+bMmaO4uDhlZGRoxIgRGj9+vF555RXbPBcuXNDzzz+vt956Sz4+Prrvvvs0duxYLVmypMj6YmNjdfz4cdWuXVvPPPOM+vXrp7CwMH399deSpPHjx+v555/XLbfcogoVKmj8+PH64IMPtGjRIlWrVk3Tp09X586ddfDgQVWqVMm23tTUVM2dO1fBwcHq27ev+vbtK6vVqnfeeUfnz5/XnXfeqZdeekkTJkxwuJ8jR45Ubm6uNm7cqHLlymnPnj2201CFhYWqWrWq3nvvPVWuXFlffvmlHnzwQUVHR6tv3762dXz++eeqWrWqNm7cqM2bN2vIkCH66quv1KZNG3399dd69913NXz4cHXs2FGxsbG25caNG6fZs2erbt26mjVrlv70pz8pIyND4eHhRerctWuXOnfurClTpuiNN97Qf/7zH40aNUqjRo3SwoULi/139CY5CtCfc5/ydBkA3Iw/SdyoYcOGevLJJ1WzZk1NnDhRQUFBqly5soYOHaqaNWvq6aef1unTp7Vz505JUnp6upo0aaKpU6eqTp06aty4sRYsWKB169Zp//79On/+vN544w09//zz6tixo+rXr69FixapoKDgqnWkpKSoXbt2io+PV/v27TVlyhS99957dvPk5eXp1VdfVVJSkpo0aaJRo0bps88+c7g+X19fRUVFyWKxKCwsTFFRUQoKCrJNf+aZZ9SxY0dVr15dgYGBSk9P14wZM9S1a1fVrVtX8+fPV1BQkN544w279f7tb39Tq1at1LhxYw0ZMkQbNmxQenq6GjdurNtuu019+vTRunXrit3PY8eOqVWrVqpfv75uueUWde/eXW3atJEk+fv7a/LkyWrWrJni4+N17733auDAgUXaoVKlSpozZ45q166twYMHq3bt2rpw4YImTZpk+3cMCAjQ5s2b7ZYbNWqU7rrrLiUkJCg9PV1hYWFF9u+yGTNmqH///kpJSVHNmjXVsmVLzZkzR4sXL1Z2Ng8uA+C9Sn9Pin/wpR4NT23bCQ0aNLAN+/r6Kjw8XPXr17eNi4yMlCSdPHlSkrR9+3atW7fO4UWohw4d0sWLF5Wbm6sWLVrYxleqVEm1a9e+ah3r1q3T1KlTtWfPHmVmZio/P1/Z2dnKysqyXWAbHBys6tWr25aJjo621eWspKQku7rz8vLUqlUr2zh/f3/9z//8j/bu3Wu33O/bKzIyUsHBwbrlllvsxn3zzTfFbvfhhx/WQw89pDVr1uj222/XXXfdZbfOV199Va+//rqOHj1qa8sre6Dq1asnH5//ZvnIyEglJibavl/+d7yybX7/b+Ln56ekpKQi+3fZ9u3bdfDgQbteKsMwVFhYqIyMDCUkJBS7jwBQlpX+kGKxOHXKxZP8/f3tvlssFrtxFotF0qVTEZf/26NHD02bNq3IuqKjo3XgwAGnazh69KjuuOMODR8+XFOmTFGlSpW0adMmDRkyRHl5eVet1XDiGpzf+/2dRZfXcXlffz/+ynFXto2jmi63lSN/+ctf1LlzZ61YsUJr1qxRWlqaZs6cqdGjR+u9997To48+qpkzZ6pFixYKDQ3VjBkzbKeoHNVwvXX8fj5HCgsLNWzYMD388MNFpt18881/uF5vEKRsbbI+IklqnfOi3ft3AJRdnO4xsSZNmuj7779XXFycatSoYfcpV66catSoIX9/f23ZssW2zJkzZ7R///5i17lt2zbl5+dr5syZat68uWrVqqWff3ZfT1SNGjUUEBCgTZs22cbl5eVp27ZtJdJjEBsbq+HDh2vZsmV67LHHNH/+fEnSF198oZYtW2rEiBFq3LixatSooUOHDrlsu7//N8nPz9f27dtVp04dh/Ne/ne+8t/4clvhknDLOYVbznm6DABuREgxsZEjR+rXX3/VPffco2+++UaHDx/WmjVrNHjwYBUUFCgkJERDhgzRuHHj9Nlnn2n37t0aOHCg3emJK1WvXl35+fl66aWXdPjwYb311lt69dVX3bZP5cqV00MPPaRx48Zp1apV2rNnj4YOHaoLFy5oyJAhLt1WSkqKVq9erYyMDH377bf6/PPPbUGoRo0a2rZtm1avXq39+/frqaeesrvD6Ea9/PLLWr58uf79739r5MiROnPmjAYPHuxw3gkTJuirr77SyJEjtWPHDh04cEAfffSRRo8e7bJ6AKA0IqSYWExMjDZv3qyCggJ17txZiYmJeuSRRxQWFmYLIjNmzFCbNm30pz/9Sbfffrtat26tpk2bFrvORo0aadasWZo2bZoSExO1ZMkSpaWluWuXJEnPPfec7rrrLg0YMEBNmjTRwYMHtXr1alWsWNGl2ykoKNDIkSOVkJCgLl26qHbt2rY7mIYPH67evXurX79+uvXWW3X69GmNGDHCZdt+7rnnNG3aNDVs2FBffPGF/vnPf6py5coO523QoIE2bNigAwcO6LbbblPjxo311FNPKTo62mX1AEBpZDGu90KDEpKZmamwsDCdPXtW5cuXt5uWnZ2tjIwMxcfHKzCQc9IwnyNHjig+Pl7ffffdVW8DvxGl/ecg7vEVTi8TpGztDbzUE5WQvcCpa1KutmxhbrZ+eKGPJCn20fflE1D8eo88183puj3tetr6WpTGtkDJu9rv7+tFTwoAADAlQgoAADCl0n8LMmAicXFx132rNopXKB/9b+EttmEA3oGQAsD0chSgnrl/83QZANyMP0kAAIApEVIAAIApcboHgOkFKkefWsdJkm7PmaFsWd1eA7fzugftjN8jpAAwPYsMVbWcsg0D8A6c7gEAAKZESIFDJ06cUMeOHVWuXDlVqFDB0+WYmsVi0YcffujpMgCgzOF0Dxx64YUXdPz4ce3YsUNhYWGeLgcA4IUIKXDo0KFDatq0qWrWrFnsPHl5efL393djVQAAb1J2TvfkZhX/yct2Yt6L1zavk5KTkzV69GilpKSoYsWKioyM1Lx585SVlaVBgwYpNDRU1atX18qVK+2W27Nnj+644w6FhIQoMjJSAwYM0KlTp2zTV61apdatW6tChQoKDw9X9+7ddejQIdv0I0eOyGKxaNmyZWrXrp2Cg4PVsGFDffXVV8XWGhcXpw8++ECLFy+WxWLRwIEDJV06rfHqq6+qZ8+eKleunP72t0sP10pPT1f16tUVEBCg2rVr66233rJbn8Vi0Wuvvabu3bsrODhYCQkJ+uqrr3Tw4EElJyerXLlyatGihV3dV8rNzdWoUaMUHR2twMBAxcXF2b29edasWapfv77KlSun2NhYjRgxQufPn7dNf/PNN1WhQgV9/PHHql27toKDg9WnTx9lZWVp0aJFiouLU8WKFTV69GgVFBTYtcWUKVPUv39/hYSEKCYmRi+99FKxdUrSTz/9pH79+qlixYoKDw9Xz549deTIkasuAwAoquyElKkxxX/eG2A/74waxc/7dh/7eWfXdzzfdVi0aJEqV66sb775RqNHj9ZDDz2ku+++Wy1bttS3336rzp07a8CAAbpw4YIk6fjx42rbtq0aNWqkbdu2adWqVfrll1/Ut29f2zqzsrI0ZswYbd26VZ999pl8fHx05513qrCw0G7bTzzxhMaOHasdO3aoVq1auueee5Sfn++wzq1bt6pLly7q27evjh8/rhdffNE27a9//at69uypXbt2afDgwVq+fLkeeeQRPfbYY9q9e7eGDRumQYMGad26dXbrnDJliu6//37t2LFDderUUf/+/TVs2DBNnDhR27ZtkySNGjWq2LabM2eOPvroI7333nvat2+f3n77bcXFxdmm+/j4aM6cOdq9e7cWLVqkzz//XOPHj7dbx4ULFzRnzhwtXbpUq1at0vr169W7d2998skn+uSTT/TWW29p3rx5ev/99+2WmzFjhho0aKBvv/1WEydO1KOPPqq1a9c6rPPChQtq166dQkJCtHHjRm3atEkhISHq0qWLcnNzi90/XJ0hi/YX3qT9hTfJkMXT5QBwE073uFHDhg315JNPSpImTpyo5557TpUrV9bQoUMlSU8//bTS09O1c+dONW/eXOnp6WrSpImmTp1qW8eCBQsUGxur/fv3q1atWrrrrrvstvHGG28oIiJCe/bsUWJiom382LFj1a3bpecETJ48WfXq1dPBgwdVp06dInVWqVJFVqtVQUFBioqKspvWv39/DR482O77wIEDNWLECEnSmDFjtGXLFj3//PNq166dbb5BgwbZwtWECRPUokULPfXUU+rcubMk6ZFHHtGgQYOKbbtjx46pZs2aat26tSwWi6pVq2Y3PSUlxTYcHx+vKVOm6KGHHtIrr7xiG5+Xl2fr9ZGkPn366K233tIvv/yikJAQ1a1bV+3atdO6devUr18/23KtWrXS448/LkmqVauWNm/erBdeeEEdO3YsUufSpUvl4+Oj119/XRbLpV+mCxcuVIUKFbR+/Xp16tSp2H1E8bJlVafcGZ4uA4CblZ2QMunn4qdZfO2/jzt4lXmv6FxK2XX9NV2hQYMGtmFfX1+Fh4erfv36tnGRkZGSpJMnT0qStm/frnXr1ikkJKTIug4dOqRatWrp0KFDeuqpp7RlyxadOnXK1oNy7Ngxu5Dy+21HR0fbtuMopFxNUlKS3fe9e/fqwQcftBvXqlUru96XK7d/eT+v3Pfs7GxlZmaqfPnyRbY7cOBAdezYUbVr11aXLl3UvXt3u1/469at09SpU7Vnzx5lZmYqPz9f2dnZysrKUrly5SRJwcHBtoByeZtxcXF27RsZGWlr/8tatGhR5Pvs2bOLNo4u/ZsdPHhQoaGhduOzs7OvejoLAFBU2QkpAeU8P+8fuPIiU4vFYjfu8l/el4NGYWGhevTooWnTphVZ1+Wg0aNHD8XGxmr+/PmKiYlRYWGhEhMTi5xauNp2nHH5F/6V+/F7hmEUGedo+87U1KRJE2VkZGjlypX69NNP1bdvX91+++16//33dfToUd1xxx0aPny4pkyZokqVKmnTpk0aMmSI8vLyHNZweZuOxl1Lu1y5f5cVFhaqadOmWrJkSZFpVapU+cP1AgD+q+yElDKoSZMm+uCDDxQXFyc/v6L/VKdPn9bevXv12muv6bbbbpMkbdq0ya01JiQkaNOmTbr//vtt47788kslJCS4fFvly5dXv3791K9fP/Xp00ddunTRr7/+qm3btik/P18zZ86Uj8+lnrD33nvPZdvdsmVLke/F9UA1adJE7777riIiIhz2COH6BCpHHwVcOlX6p9y/eeSx+ADcj5BiYiNHjtT8+fN1zz33aNy4capcubIOHjyopUuXav78+ba7R+bNm6fo6GgdO3bMdu2Eu4wbN059+/ZVkyZN1KFDB/3rX//SsmXL9Omnn7p0Oy+88IKio6PVqFEj+fj46B//+IeioqJUoUIFVa9eXfn5+XrppZfUo0cPbd68Wa+++qrLtr1582ZNnz5dvXr10tq1a/WPf/xDK1Y4fr/IvffeqxkzZqhnz5565plnVLVqVR07dkzzFv9dA4ePVmT0TTdcj5Gfq5NnLuovy9Zr8xNdbnh9pYFFhmr5/GQbBuAdys7dPWVQTEyMNm/erIKCAnXu3FmJiYl65JFHFBYWJh8fH/n4+Gjp0qXavn27EhMT9eijj2rGDPdeXNirVy+9+OKLmjFjhurVq6fXXntNCxcuVHJysku3ExISomnTpikpKUnNmjXTkSNH9Mknn8jHx0eNGjXSrFmzNG3aNCUmJmrJkiV2tyffqMcee0zbt29X48aNNWXKFM2cOdN2we+VgoODtXHjRt18883q3bu3EhISNHjwYOVkZ6tcSKjDZQAAjlkMwzDVnyWZmZkKCwvT2bNni3SXZ2dnKyMjQ/Hx8QoMDPRQhfAmcXFxSklJsbt76Hrs/PE3l9Qj/X9Pys8/KnXdyVLZk3I9b7kNUrb2Bl66qywhe4Eu6tp//q+2bGFutn544dJjB2IffV8+Ae7//0pJvp23NL5RuDTWjEuu9vv7etGTAgAATImQAgAATIkLZ4Gr4HH2AOA5hBQApmfIoh+NyrZhAN6hVIYUk13rC3hEoRf9GGTLqtY5czxdBgA3c+qalLS0NDVr1kyhoaGKiIhQr169tG/fPrt5Bg4cKIvFYvdp3ry5S4q9/HTQyy/gA7yRUZCvgsJCZeU6/8RgAChNnOpJ2bBhg0aOHKlmzZopPz9fTzzxhDp16qQ9e/bYPS69S5cuWrhwoe17QECAS4r19fVVhQoVbO9WCQ4OLvbx5ICZGPkuegOyYehi5hntPJGtc7le1JUCwCs5FVJWrVpl933hwoWKiIjQ9u3b1aZNG9t4q9Va5O25rnJ5vVe+BA4ws5NnLrpoTYbOXMjX0t3nvOq5q1bl6r2AZyRJfXOfVo5c84cPAHO7oWtSzp49K0mqVKmS3fj169crIiJCFSpUUNu2bfXss88qIiLC4TpycnKUk5Nj+56ZmXnVbVosFkVHRysiIsLu5XGAmf1l2XqXrKegUDp1oUD53pRQJPmoUA19DtuGAXiH6w4phmFozJgxat26tRITE23ju3btqrvvvlvVqlVTRkaGnnrqKbVv317bt2+X1Vr0pWBpaWmaPHmy09v39fWVr6/v9ZYPuNVP5wo8XQIAlDrXHVJGjRqlnTt3Fnnrbr9+/WzDiYmJSkpKUrVq1bRixQr17t27yHomTpyoMWPG2L5nZmYqNjb2essCAABlxHWFlNGjR+ujjz7Sxo0bVbVq1avOGx0drWrVqunAgQMOp1utVoc9LAAAwLs5FVIMw9Do0aO1fPlyrV+/XvHx8X+4zOnTp/XDDz8oOjr6uosEAADex6nnpIwcOVJvv/223nnnHYWGhurEiRM6ceKELl68dOfC+fPnNXbsWH311Vc6cuSI1q9frx49eqhy5cq68847S2QHAABA2eRUT0p6erokKTk52W78woULNXDgQPn6+mrXrl1avHixfvvtN0VHR6tdu3Z69913FRoa6rKiAXif0wb/DwG8jdOne64mKChIq1evvqGCAOBKFxWopjmveboMAG7m1OkeAAAAdyGkAAAAUyKkADA9q3K1NGCKlgZMkVUueg8SANO7ocfiA4A7+KhQzX322oYBeAd6UgAAgCkRUgAAgCkRUgAAgCkRUgAAgCkRUgAAgClxdw+AUuGCwdvSAW9DSAFgehcVqLo5Cz1dBgA343QPAAAwJUIKAAAwJUIKANOzKlcL/Kdrgf90HosPeBGuSQFgej4qVHvfHZeG83gsPuAt6EkBAACmREgBAACmREgBAACmREgBAACmREgBAACmREgBAACmxC3IAEzvogIVl/2Op8sA4Gb0pAAAAFMipAAAAFMipAAwPaty9bL/bL3sP5vH4gNehJACwPR8VKhuvt+om+838hGPxQe8BSEFAACYEiEFAACYEiEFAACYEiEFAACYEiEFAACYEiEFAACYEo/FB2B6F2VVQvYC2zAA70BIAVAKWHRRgZ4uAoCbcboHAACYEiEFgOkFKE/P+7+q5/1fVYDyPF0OADchpAAwPV8VqI/vRvXx3ShfFXi6HABuQkgBAACmREgBAACmREgBAACmxC3IAByKe3yFp0sA4OXoSQEAAKZESAEAAKbE6R4ApndRVjXJftU2DMA7EFIAlAIW/aryni4CgJtxugcAAJgSPSkATC9AeXrS721J0t/y71Ou/D1cEQB3oCcFgOn5qkD3+63V/X5reSw+4EWcCilpaWlq1qyZQkNDFRERoV69emnfvn128xiGodTUVMXExCgoKEjJycn6/vvvXVo0AAAo+5wKKRs2bNDIkSO1ZcsWrV27Vvn5+erUqZOysrJs80yfPl2zZs3S3LlztXXrVkVFRaljx446d+6cy4sHAABll1PXpKxatcru+8KFCxUREaHt27erTZs2MgxDs2fP1hNPPKHevXtLkhYtWqTIyEi98847GjZsmOsqBwAAZdoNXZNy9uxZSVKlSpUkSRkZGTpx4oQ6depkm8dqtapt27b68ssvHa4jJydHmZmZdh8AAIDrvrvHMAyNGTNGrVu3VmJioiTpxIkTkqTIyEi7eSMjI3X06FGH60lLS9PkyZOvtwwAKNV4RxJQvOvuSRk1apR27typv//970WmWSwWu++GYRQZd9nEiRN19uxZ2+eHH3643pIAAEAZcl09KaNHj9ZHH32kjRs3qmrVqrbxUVFRki71qERHR9vGnzx5skjvymVWq1VWK4+5BlC8bAWodc6LtmEA3sGpnhTDMDRq1CgtW7ZMn3/+ueLj4+2mx8fHKyoqSmvXrrWNy83N1YYNG9SyZUvXVAzA6xjy0Y9GFf1oVJHB450Ar+FUT8rIkSP1zjvv6J///KdCQ0Nt16CEhYUpKChIFotFKSkpmjp1qmrWrKmaNWtq6tSpCg4OVv/+/UtkBwAAQNnkVEhJT0+XJCUnJ9uNX7hwoQYOHChJGj9+vC5evKgRI0bozJkzuvXWW7VmzRqFhoa6pGAA3sdf+Rrr964k6fn8fsrjjR6AV3DqJ90wjD+cx2KxKDU1VampqddbEwDY8VO+hvldugtmdv5dhBTAS3ByFwAAmBIhBQAAmBIhBQAAmBIhBQAAmBIhBQAAmBIhBQAAmBL38QEwvWwFqGPOdNswAO9ASAFgeoZ8dMCo+sczAihTON0DAABMiZ4UAKbnr3yN9PtQkvRyfi+eOAt4CX7SAZien/KV4rdMkvRafndCCuAlON0DAABMiZACAABMiZACAABMiZACAABMiZACAABMiZACAABMifv4AJhejgL0p5wptmEA3oGQAsD0CuWjnUZ1T5cBwM043QMAAEyJnhQApuevfA3yXSlJWljQlSfOAl6Cn3QApuenfE3y/7sk6a2CjoQUwEtwugcAAJgSIQUAAJgSIQUAAJgSIQUAAJgSIQUAAJgSIQUAAJgS9/EB/y/u8RWeLgHFyFGA/pz7pG0YnsXPCtyFkALA9Arloy2FdT1dBgA343QPAAAwJXpSAJien/J1j+/nkqS/F7RXPv/rArwCP+kATM9f+Zri/6Yk6f2CNoQUwEtwugcAAJgSIQUAAJgSIQUAAJgSIQUAAJgSIQUAAJgSIQUAAJgS9/EBML1c+WtQ7jjbMADvQEgBSjFveYdKgXy1rrCxp8sA4Gac7gEAAKZETwoA0/NTvnr5bpYkfVjQiifOAl6Cn3QApuevfD3v/5okaUXBrYQUwEtwugcAAJgSIQUAAJgSIQUAAJiS0yFl48aN6tGjh2JiYmSxWPThhx/aTR84cKAsFovdp3nz5q6qFwAAeAmnQ0pWVpYaNmyouXPnFjtPly5ddPz4cdvnk08+uaEiAQCA93H6EvmuXbuqa9euV53HarUqKirquosCAAAokfv41q9fr4iICFWoUEFt27bVs88+q4iICIfz5uTkKCcnx/Y9MzOzJEoCUIrlyl8jch+2DQPwDi6/cLZr165asmSJPv/8c82cOVNbt25V+/bt7YLI76WlpSksLMz2iY2NdXVJAEq5Avnqk8Lm+qSwuQrk6+lyALiJy3tS+vXrZxtOTExUUlKSqlWrphUrVqh3795F5p84caLGjBlj+56ZmUlQAQAAJf/YxujoaFWrVk0HDhxwON1qtcpqtZZ0GQBKMV8VqLPPVknS6sJm9KYAXqLEQ8rp06f1ww8/KDo6uqQ3BaCMClCeXgmYI0lKyF6gi4QUwCs4HVLOnz+vgwcP2r5nZGRox44dqlSpkipVqqTU1FTdddddio6O1pEjRzRp0iRVrlxZd955p0sLBwAAZZvTIWXbtm1q166d7fvl60keeOABpaena9euXVq8eLF+++03RUdHq127dnr33XcVGhrquqoBAECZ53RISU5OlmEYxU5fvXr1DRUEAAAg8e4eAABgUoQUAABgSoQUAABgSiV+CzIA3Kg8+Wls3jDbMADvwE87ANPLl5/eL2jr6TIAuBmnewAAgCnRkwLA9HxVoDY+OyVJGwsb8Fh8wEsQUgCYXoDytDBghiQeiw94E073AAAAUyKkAAAAUyKkAAAAUyKkAAAAUyKkAAAAUyKkAAAAU+IWZACmlyc/PZU30DYMwDvw0w7A9PLlp7cKOnm6DABuxukeAABgSvSkADA9HxXqf3z+LUn6prCOCvn7CvAKhBQApmdVrpYG/E3S5cfiB3q4IgDuwJ8jAADAlAgpAADAlAgpAADAlAgpAADAlAgpAADAlAgpAADAlLgFGYDp5ctPU/PusQ0D8A78tAMwvTz5aV5BD0+XAcDNON0DAABMiZ4UAKbno0IlWjIkSbuNeB6LD3gJQgoA07MqVx9Zn5LEY/EBb8KfIwAAwJQIKQAAwJQIKQAAwJQIKQAAwJQIKQAAwJQIKQAAwJS4BRmA6eXLT7Pze9uGAXgHftoBmF6e/DQ7v4+nywDgZpzuAQAApkRPCgDTs6hQNSw/S5IOGjEy+PsK8ApeF1LiHl9RYus+8ly3Els3/qsk/w1hToHK1VrreEk8Fh/wJvw5AgAATImQAgAATImQAgAATImQAgAATImQAgAATImQAgAATMnrbkEGUPrky0+v5XezDQPwDk73pGzcuFE9evRQTEyMLBaLPvzwQ7vphmEoNTVVMTExCgoKUnJysr7//ntX1QvAC+XJT2n59yot/17lEVIAr+F0SMnKylLDhg01d+5ch9OnT5+uWbNmae7cudq6dauioqLUsWNHnTt37oaLBQAA3sPpP0m6du2qrl27OpxmGIZmz56tJ554Qr17X3pj6aJFixQZGal33nlHw4YNu7FqAXgliwp1k+W0JOknI5zH4gNewqU/6RkZGTpx4oQ6depkG2e1WtW2bVt9+eWXDpfJyclRZmam3QcAfi9QudpkfUSbrI8oULmeLgeAm7g0pJw4cUKSFBkZaTc+MjLSNu1KaWlpCgsLs31iY2NdWRIAACilSqTP1GKx2H03DKPIuMsmTpyos2fP2j4//PBDSZQEAABKGZdeJh8VFSXpUo9KdHS0bfzJkyeL9K5cZrVaZbVaXVkGAAAoA1zakxIfH6+oqCitXbvWNi43N1cbNmxQy5YtXbkpAABQxjndk3L+/HkdPHjQ9j0jI0M7duxQpUqVdPPNNyslJUVTp05VzZo1VbNmTU2dOlXBwcHq37+/SwsHAABlm9MhZdu2bWrXrp3t+5gxYyRJDzzwgN58802NHz9eFy9e1IgRI3TmzBndeuutWrNmjUJDQ11XNQAAKPOcDinJyckyDKPY6RaLRampqUpNTb2RugDApkC+Wpzf0TYMwDvwfGkAppcrfz2dP8jTZQBwMx7bCAAATImeFAClgKFKuvT+r18VKsnxc5cAlC2EFACmF6QcfRs4XJKUkL1AFxXo4YoAuAOnewAAgCnRk+Ll4h5f4ekSAABwiJ4UAABgSoQUAABgSoQUAABgSoQUAABgSlw4C8D0CuSr9wva2IYBeAdCCgDTy5W/xuYN93QZANyM0z0AAMCU6EkBUAoYClKOJOmirOKx+IB3oCcFgOkFKUd7Awdrb+BgW1gBUPYRUgAAgClxugcAUOaV5CtAjjzXrcTW7e3oSQEAAKZESAEAAKZESAEAAKZESAEAAKbEhbMATK9QPlpR8D+2YQDegZACwPRyFKCReSmeLgOAm/EnCQAAMCVCCgAAMCVCCgDTC1K2jgT215HA/gpStqfLAeAmhBQAAGBKhBQAAGBKhBQAAGBKhBQAAGBKhBQAAGBKhBQAAGBKPHEWgOkVykefFzSyDQPwDoQUAKaXowANzhvv6TIAuBl/kgAAAFMipAAAAFMipAAwvSBla491kPZYB/FYfMCLcE0KgFIh2JLj6RIAuBk9KQAAwJQIKQAAwJQ43VMKxD2+wtMlAADgdvSkAAAAUyKkAAAAU+J0DwDTK5SPthQm2IYBeAdCCgDTy1GA/pz7lKfLAOBm/EkCAABMiZACAABMiZACwPSClK3t1mHabh3GY/EBL+LykJKamiqLxWL3iYqKcvVmAHiZcMs5hVvOeboMAG5UIhfO1qtXT59++qntu6+vb0lsBgAAlGElElL8/PzoPQEAADekRK5JOXDggGJiYhQfH68///nPOnz4cLHz5uTkKDMz0+4DAADg8pBy6623avHixVq9erXmz5+vEydOqGXLljp9+rTD+dPS0hQWFmb7xMbGurokAABQCrk8pHTt2lV33XWX6tevr9tvv10rVlx6Od6iRYsczj9x4kSdPXvW9vnhhx9cXRIAACiFSvyJs+XKlVP9+vV14MABh9OtVqusVmtJlwGgFCuUj/638BbbMADvUOIhJScnR3v37tVtt91W0psCUEblKEA9c//m6TIAuJnL/yQZO3asNmzYoIyMDH399dfq06ePMjMz9cADD7h6UwAAoAxzeU/Kjz/+qHvuuUenTp1SlSpV1Lx5c23ZskXVqlVz9aYAAEAZ5vKQsnTpUlevEoCXC1SOPrWOkyTdnjND2eI6NsAblPg1KQBwoywyVNVyyjYMwDtwmTwAADAlQgoAADAlQgoAADAlrkkBAMCE4h5fUWLrPvJctxJbtyvRkwIAAEyJnhQApmfIov2FN9mGAXgHQgoA08uWVZ1yZ3i6DABuxukeAABgSoQUAABgSoQUAKYXqBytCRinNQHjFKgcT5cDwE24JgWA6VlkqJbPT7ZhAN6BnhQAAGBKhBQAAGBKhBQAAGBKhBQAAGBKXDjrQiX5ngUAALwNIQWA6Rmy6Eejsm0YgHcgpAAwvWxZ1TpnjqfLAOBmXJMCAABMiZACAABMiZACwPSsytU/A57UPwOelFW5ni4HgJtwTQoA0/NRoRr6HLYNA/AO9KQAAABTIqQAAABTIqQAAABTIqQAAABTIqQAAABT4u4eAKXCaSPU0yUAcDNCCgDTu6hANc15zdNlAHAzTvcAAABTIqQAAABTIqQAMD2rcrU0YIqWBkzhsfiAF+GaFACm56NCNffZaxsG4B3oSQEAAKZESAEAAKZESAEAAKZESAEAAKZESAEAAKbE3T0ASoULhtXTJQBwM0IKANO7qEDVzVno6TIAuBmnewAAgCkRUgAAgCkRUgCYnlW5WuA/XQv8p/NYfMCLcE0KANPzUaHa++64NJzHY/EBb0FPCgAAMCVCCgAAMKUSCymvvPKK4uPjFRgYqKZNm+qLL74oqU0BAIAyqERCyrvvvquUlBQ98cQT+u6773Tbbbepa9euOnbsWElsDgAAlEElElJmzZqlIUOG6C9/+YsSEhI0e/ZsxcbGKj09vSQ2BwAAyiCX392Tm5ur7du36/HHH7cb36lTJ3355ZdF5s/JyVFOTo7t+9mzZyVJmZmZri5NklSYc6FE1gug5BQoW5kW49JwzgUV6trv8LnasoW52f8dzrkgGdw5BOeVxt9XJVHz5XUahuGydbo8pJw6dUoFBQWKjIy0Gx8ZGakTJ04UmT8tLU2TJ08uMj42NtbVpQEoxcJsQ/eXyLI/veL8egFJCpvt6QqcV5I1nzt3TmFhYX884zUoseekWCwWu++GYRQZJ0kTJ07UmDFjbN8LCwv166+/Kjw8XBaLRZmZmYqNjdUPP/yg8uXLl1S5pQ7t4hjtUjzaxjHaxTHaxTHaxbHL7bJnzx7FxMS4bL0uDymVK1eWr69vkV6TkydPFuldkSSr1Sqr1f7tphUqVCgyX/ny5TkgHKBdHKNdikfbOEa7OEa7OEa7OHbTTTfJx8d1l7u6/MLZgIAANW3aVGvXrrUbv3btWrVs2dLVmwMAAGVUiZzuGTNmjAYMGKCkpCS1aNFC8+bN07FjxzR8+PCS2BwAACiDSiSk9OvXT6dPn9Yzzzyj48ePKzExUZ988omqVavm9LqsVqv++te/Fjkl5O1oF8dol+LRNo7RLo7RLo7RLo6VVLtYDFfeKwQAAOAivLsHAACYEiEFAACYEiEFAACYEiEFAACYEiEFAACYkkdDSnp6uho0aGB7cl+LFi20cuXKqy6zYcMGNW3aVIGBgbrlllv06quvuqla93G2XdavXy+LxVLk8+9//9uNVbtfWlqaLBaLUlJSrjqfNxwzv3ct7eItx0xqamqRfYyKirrqMt5wvDjbLt5yvEjSTz/9pPvuu0/h4eEKDg5Wo0aNtH379qsu4w3HjLPt4qpjpsTe3XMtqlatqueee041atSQJC1atEg9e/bUd999p3r16hWZPyMjQ3fccYeGDh2qt99+W5s3b9aIESNUpUoV3XXXXe4uv8Q42y6X7du3z+4xzVWqVCnxWj1l69atmjdvnho0aHDV+bzlmLnsWtvlMm84ZurVq6dPP/3U9t3X17fYeb3peHGmXS4r68fLmTNn1KpVK7Vr104rV65URESEDh065PBVLZd5wzFzPe1y2Q0fM4bJVKxY0Xj99dcdThs/frxRp04du3HDhg0zmjdv7o7SPOpq7bJu3TpDknHmzBn3FuUh586dM2rWrGmsXbvWaNu2rfHII48UO683HTPOtIu3HDN//etfjYYNG17z/N5yvDjbLt5yvEyYMMFo3bq1U8t4wzFzPe3iqmPGNNekFBQUaOnSpcrKylKLFi0czvPVV1+pU6dOduM6d+6sbdu2KS8vzx1lut21tMtljRs3VnR0tDp06KB169a5qUL3GzlypLp166bbb7/9D+f1pmPGmXa5zBuOmQMHDigmJkbx8fH685//rMOHDxc7rzcdL860y2Vl/Xj56KOPlJSUpLvvvlsRERFq3Lix5s+ff9VlvOGYuZ52uexGjxmPh5Rdu3YpJCREVqtVw4cP1/Lly1W3bl2H8544caLIm5QjIyOVn5+vU6dOuaNct3GmXaKjozVv3jx98MEHWrZsmWrXrq0OHTpo48aNbq665C1dulTffvut0tLSrml+bzlmnG0Xbzlmbr31Vi1evFirV6/W/PnzdeLECbVs2VKnT592OL+3HC/Otou3HC+HDx9Wenq6atasqdWrV2v48OF6+OGHtXjx4mKX8YZj5nraxWXHzA31w7hATk6OceDAAWPr1q3G448/blSuXNn4/vvvHc5bs2ZNY+rUqXbjNm3aZEgyjh8/7o5y3caZdnGke/fuRo8ePUqwQvc7duyYERERYezYscM27o9Oa3jDMXM97eJIWTxmrnT+/HkjMjLSmDlzpsPp3nC8OPJH7eJIWTxe/P39jRYtWtiNGz169FVP3XjDMXM97eLI9RwzHu9JCQgIUI0aNZSUlKS0tDQ1bNhQL774osN5o6KidOLECbtxJ0+elJ+fn8LDw91Rrts40y6ONG/eXAcOHCjBCt1v+/btOnnypJo2bSo/Pz/5+flpw4YNmjNnjvz8/FRQUFBkGW84Zq6nXRwpi8fMlcqVK6f69esXu5/ecLw48kft4khZPF6io6OL9FgnJCTo2LFjxS7jDcfM9bSLI9dzzHj07h5HDMNQTk6Ow2ktWrTQv/71L7txa9asUVJSkvz9/d1RnsdcrV0c+e677xQdHV2CFblfhw4dtGvXLrtxgwYNUp06dTRhwgSHdyd4wzFzPe3iSFk8Zq6Uk5OjvXv36rbbbnM43RuOF0f+qF0cKYvHS6tWrbRv3z67cfv371e1atWKXcYbjpnraRdHruuYcarfxcUmTpxobNy40cjIyDB27txpTJo0yfDx8THWrFljGIZhPP7448aAAQNs8x8+fNgIDg42Hn30UWPPnj3GG2+8Yfj7+xvvv/++p3ahRDjbLi+88IKxfPlyY//+/cbu3buNxx9/3JBkfPDBB57aBbe58rSGtx4zV/qjdvGWY+axxx4z1q9fbxw+fNjYsmWL0b17dyM0NNQ4cuSIYRjee7w42y7ecrx88803hp+fn/Hss88aBw4cMJYsWWIEBwcbb7/9tm0ebzxmrqddXHXMeDSkDB482KhWrZoREBBgVKlSxejQoYPtF7FhGMYDDzxgtG3b1m6Z9evXG40bNzYCAgKMuLg4Iz093c1Vlzxn22XatGlG9erVjcDAQKNixYpG69atjRUrVnigcve78pextx4zV/qjdvGWY6Zfv35GdHS04e/vb8TExBi9e/e2u7bLW48XZ9vFW44XwzCMf/3rX0ZiYqJhtVqNOnXqGPPmzbOb7q3HjLPt4qpjxmIYhuFc3wsAAEDJ8/iFswAAAI4QUgAAgCkRUgAAgCkRUgAAgCkRUgAAgCkRUgAAgCkRUgAAgCkRUgAAgCkRUgAAgCkRUgAAgCkRUgAAgCn9Hz67toSU9QSdAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiwAAAGxCAYAAABBZ+3pAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAABH50lEQVR4nO3deVhUZf8G8HvYhkUWAYFBEVARFRHXBHLBTBHXXHINMPdckQxFs7B6JXPD3VdTccnEApfSN8VE3HBD0cpdEVxA0hQUZT+/P/w5MTAggzNwgPtzXXN1luc88z2PBDfnHJ6RCIIggIiIiEjEtCq7ACIiIqI3YWAhIiIi0WNgISIiItFjYCEiIiLRY2AhIiIi0WNgISIiItFjYCEiIiLRY2AhIiIi0WNgISIiItFjYCGq4U6ePImQkBA8ffq0skt5a+Hh4ZBIJDh37twb244cORIODg6aL4qI1IKBhaiGO3nyJObNm1ctAosq5s6di127dlV2GURURjqVXQARUWVo2LBhZZdARCrgFRaiGiwkJASfffYZAMDR0RESiQQSiQRHjhwBAERERMDDwwNGRkaoVasWvL29ceHCBYU+Ro4ciVq1auHq1avw9vaGkZERZDIZvv32WwDAqVOn0KFDBxgZGaFx48bYvHmzwvGvb+NER0fj448/hrm5OYyMjNCnTx/cvn27XOf15MmTN/al7JbQqlWr0KlTJ1hZWcHIyAiurq747rvvkJubq9DuwoUL6N27N6ysrCCVSmFra4tevXrh3r175aqXiN6MgYWoBhszZgymTJkCAIiKikJcXBzi4uLQunVrzJ8/H8OGDUOzZs2wc+dObN26Fc+ePUPHjh1x+fJlhX5yc3MxYMAA9OrVC3v27IGPjw+Cg4Mxe/Zs+Pv7Y9SoUdi1axecnZ0xcuRIxMfHF6tl9OjR0NLSwvbt2xEWFoYzZ87Ay8urXLeqytvXrVu3MHz4cGzduhW//vorRo8ejYULF2L8+PHyNpmZmejWrRsePnyIVatWITo6GmFhYahfvz6ePXumcq1EVEYCEdVoCxcuFAAIiYmJ8m3JycmCjo6OMGXKFIW2z549E2xsbITBgwfLt/n7+wsAhMjISPm23NxcoU6dOgIA4fz58/Ltjx8/FrS1tYXAwED5tk2bNgkAhP79+yu814kTJwQAwjfffFPmc1GlL39/f8He3r7EvvLz84Xc3Fxhy5Ytgra2tvDPP/8IgiAI586dEwAIu3fvLnNdRPT2eIWFiIo5cOAA8vLy4Ofnh7y8PPlLX18fnTt3lt8yek0ikaBnz57ydR0dHTRq1AgymQytWrWSbzc3N4eVlRWSkpKKveeIESMU1j09PWFvb4+YmBiV6y9vXxcuXEDfvn1hYWEBbW1t6Orqws/PD/n5+bh+/ToAoFGjRqhduzZmzpyJtWvXFrvaRESawcBCRMU8fPgQANCuXTvo6uoqvCIiIvDo0SOF9oaGhtDX11fYpqenB3Nz82J96+npISsrq9h2GxsbpdseP36scv3l6Ss5ORkdO3bE/fv3sWzZMhw7dgxnz57FqlWrAAAvX74EAJiamiI2NhYtW7bE7Nmz4eLiAltbW3z55ZfFnnUhIvXhXwkRUTGWlpYAgJ9//hn29vYV8p6pqalKtzVq1KhC+tq9ezcyMzMRFRWlcM4JCQnF2rq6umLHjh0QBAGXLl1CeHg4vvrqKxgYGGDWrFkq10tEb8YrLEQ1nFQqBfDvFQQA8Pb2ho6ODm7duoW2bdsqfanbDz/8oLB+8uRJJCUlwcvLq0L6kkgkAP4dDwAQBAHr168v9Rg3NzcsXboUZmZmOH/+vMq1ElHZ8AoLUQ3n6uoKAFi2bBn8/f2hq6sLZ2dnfPXVV5gzZw5u376NHj16oHbt2nj48CHOnDkDIyMjzJs3T611nDt3DmPGjMGHH36Iu3fvYs6cOahbty4mTpxYIX1169YNenp6GDZsGIKCgpCVlYU1a9bgyZMnCu1+/fVXrF69Gh988AEaNGgAQRAQFRWFp0+folu3birXSkRlwyssRDWcl5cXgoOD8csvv6BDhw5o164d4uPjERwcjJ9//hnXr1+Hv78/vL29ERQUhKSkJHTq1EntdWzYsAE5OTkYOnQopk6dirZt2+LIkSNKn4PRRF9NmjRBZGQknjx5ggEDBmDKlClo2bIlli9frtDOyckJZmZm+O6779C3b198+OGHOH/+PMLDwzF27FiVayWispEIgiBUdhFEVHOFh4fj448/xtmzZzVyq4mIqgdeYSEiIiLR4zMsRCR6giAgPz+/1Dba2tryB2eJqPrhLSEiEr3Xt41KExMTU66/KCKiqoGBhYhE7/Hjx0hMTCy1jbOzM4yNjSuoIiKqaAwsREREJHp86JaIiIhEr9o8dFtQUIAHDx7A2NiYD94RERFVEYIg4NmzZ7C1tYWWVsnXUapNYHnw4AHs7OwquwwiIiIqh7t376JevXol7q82geX1w3Z3796FiYlJJVdDRG8j8+9kGH3v+Wp5zEkY1alfyRURkaZkZGTAzs7ujQ/NV5vA8vo2kImJCQMLURWnnWUMI+mr/6e1jY1hxP+niaq9Nz3OwYduiYiISPQYWIhIfCTaypeJqMZiYCEi8dGRKl8mohqr2jzDQkQkZoIgIC8v742fiURU3Whra0NHR+etpxxhYCEi8Sk8AXc1mIw7JycHKSkpePHiRWWXQlQpDA0NIZPJoKenV+4+GFiISHzyXipfroIKCgqQmJgIbW1t2NraQk9Pj5NbUo0hCAJycnLw999/IzExEU5OTqVODlcaBhYiIg3KyclBQUEB7OzsYGhoWNnlEFU4AwMD6OrqIikpCTk5OdDX1y9XP3zoloioApT3t0qi6kAdX//8P4iIiIhEj4GFiIiIRE+lwBIaGop27drB2NgYVlZW+OCDD3Dt2jWFNoIgICQkBLa2tjAwMICXlxf++uuvN/YdGRmJZs2aQSqVolmzZti1a5dqZ0JERDVWeHg4zMzMKrsM0iCVAktsbCwmTZqEU6dOITo6Gnl5eejevTsyMzPlbb777jssWbIEK1euxNmzZ2FjY4Nu3brh2bNnJfYbFxeHIUOGwNfXFxcvXoSvry8GDx6M06dPl//MiIhI1BwcHBAWFlbZZVAVodJfCf32228K65s2bYKVlRXi4+PRqVMnCIKAsLAwzJkzBwMGDAAAbN68GdbW1ti+fTvGjx+vtN+wsDB069YNwcHBAIDg4GDExsYiLCwMP/74Y3nOi4iqMk7NT/8vPz8fEolEIw8t5+bmQldXV+39kma81VdAeno6AMDc3BwAkJiYiNTUVHTv3l3eRiqVonPnzjh58mSJ/cTFxSkcAwDe3t6lHpOdnY2MjAyFFxFVE9V4an5BEJCZmVkpL0GFSfgKCgqwYMECNGrUCFKpFPXr18d//vMf+f4//vgD7733HgwMDGBhYYFx48bh+fPn8v0jR47EBx98gEWLFkEmk8HCwgKTJk1Cbm4uAMDLywtJSUmYPn06JBKJfG6a17d2fv31V/ljAklJSXjy5An8/PxQu3ZtGBoawsfHBzdu3Cjz+dy5cwcSiQQ7d+6El5cX9PX1sW3bNoSEhKBly5YKbcPCwuDg4FDmc6GKUe55WARBQGBgIDp06IDmzZsDAFJTUwEA1tbWCm2tra2RlJRUYl+pqalKj3ndnzKhoaGYN29eectXicOsfRrr+863vTTSryZr1hRNjYWmaWqsq+p4aEp1+Zp+8eIFatWqVQnVAM+fP4eRkVGZ2gYHB2P9+vVYunQpOnTogJSUFFy9ehXAq3Po0aMH3N3dcfbsWaSlpWHMmDGYPHkywsPD5X3ExMRAJpMhJiYGN2/exJAhQ9CyZUuMHTsWUVFRcHNzw7hx4zB27FiF937x4gVCQ0Px/fffw8LCAlZWVhg+fDhu3LiBvXv3wsTEBDNnzkTPnj1x+fJlXHmYibv/vECBIODSvadKz+d+yqtfaqfP+Ayfzv0GQfOXQU9PD2f+uIas3HyF4x48fYnc/AL5tieZOTh8+DD0jM2x9sc9SL5zG0ETR8PSvjEGDvcv2+AX0aKeWbmOK4uSxuBtabLmsih3YJk8eTIuXbqE48ePF9tXdBZHQRDeOLOjqscEBwcjMDBQvp6RkQE7O7uylE5ERKV49uwZli1bhpUrV8Lf/9UP5IYNG6JDhw4AgB9++AEvX77Eli1b5AFo5cqV6NOnDxYsWCD/BbR27dpYuXIltLW10aRJE/Tq1Qu///47xo4dC3Nzc2hra8PY2Bg2NjYK75+bm4vVq1fDzc0NAORB5cSJE/D09JTXYGdnh927d8PZo1uZz+2j0Z/gfZ8+Ko+JiakZgr9ZCG1tbTg2aoxOXbvj9PHYcgcWUl25AsuUKVOwd+9eHD16FPXq1ZNvf/1Fl5qaCplMJt+elpZW7ApKYTY2NsWuprzpGKlUCqm0el0qJqL/l/tC+XI1YGhoqHDrpKLfuyyuXLmC7OxsdO3atcT9bm5uCldr3n33XRQUFODatWvy790uLi7Q1v73GSSZTIY//vjjje+vp6eHFi1aKLyfjo4O2rdvL99mYWEBZ2dnXLlyRaXA0qxFyzK3Laxh4yYK52JpZY0bVy+Xqy8qH5UCiyAImDJlCnbt2oUjR47A0dFRYb+joyNsbGwQHR2NVq1aAXg1LXVsbCwWLFhQYr8eHh6Ijo7G9OnT5dsOHjwoT9JERNWFRCIp822ZymJgYFDq/tKugBfeXvSBVolEgoKCgjK9f+F+Snr2pixX74v1bag49hItrWL95+UVfzZFR6f4uQhlOBdSH5Ueup00aRK2bduG7du3w9jYGKmpqUhNTcXLl68+nEwikSAgIADz58/Hrl278Oeff2LkyJEwNDTE8OHD5f34+fnJ/yIIAKZNm4aDBw9iwYIFuHr1KhYsWIBDhw4hICBAPWdJRERl5uTkBAMDA/z+++9K9zdr1gwJCQkKU1qcOHECWlpaaNy4cZnfR09PD/n5+W9s16xZM+Tl5SlMdfH48WNcv34dTZs2LfP7KWNuboFHf6cphJZrf735KhBVPJUCy5o1a5Ceng4vLy/IZDL5KyIiQt4mKCgIAQEBmDhxItq2bYv79+/j4MGDMDY2lrdJTk5GSkqKfN3T0xM7duzApk2b0KJFC4SHhyMiIkLh8h8REVUMfX19zJw5E0FBQdiyZQtu3bqFU6dOYcOGDQCAESNGQF9fH/7+/vjzzz8RExODKVOmwNfXt9Rb+UU5ODjg6NGjuH//Ph49elRiOycnJ/Tr1w9jx47F8ePHcfHiRXz00UeoW7cu+vXr91bn2tajA548foRNa5bh7p1E7Ahfj+Mxh96qT9IMlW8JvYlEIkFISAhCQkJKbHPkyJFi2wYNGoRBgwapUg4REWnI3LlzoaOjgy+++AIPHjyATCbDhAkTALx6FubAgQOYNm0a2rVrB0NDQwwcOBBLlixR6T2++uorjB8/Hg0bNkR2dnapP2M2bdqEadOmoXfv3sjJyUGnTp2wf//+t55HpYGTM2b/ZxE2rFyCdcsW4f2efeA/fjIit29+q35J/SSCKn+YL2IZGRkwNTVFeno6TExM1No3/6y5YlTVP+PlnzWrX2ZaEoxWv3roMnPiJRhZ2VfZr+msrCwkJibC0dER+vr6lV1StaSpP+PVpJr2Z82l/X9Q1p/f/PBDIiIiEj0GFiISH07NT0RFMLAQkfhU46n5iah8GFiIiIhI9BhYiIiISPQYWIhIfKrx1PxEVD4MLERERCR6DCxEREQkegwsREREJHoMLEREVKm8vLwUPuzWwcEBYWFhGn/fC2dPYeD7nmjjWAcBo0do/P2qqrNxx+FmVxtPnz6t1DpU+iwhIiIiTTt79iyMjIw0/j6Lvvoczi6uWL31JxgY1tL4+9Hb4RUWIiISlTp16sDQ0FDj73MvKRHveHaCtawuTExNi+0XBAF5eXkar4PKhoGFiMRHoqV8uToQBCAns3JeKnzWrZeXF6ZMmYKAgADUrl0b1tbWWLduHTIzM/Hxxx/D2NgYDRs2xP/+9z+F4y5fvoyePXuiVq1asLa2hq+vLx49eiTfn5mZCT8/P9SqVQsymQyLFy8u9t5FbwktWbIErq6uMDIygp2dHSZOnIjnz5/L9+/ZuR0dXOxx4sjv+KBLe7g718MnHw3C3w9TlZ7b/bvJr25xPPkHX86YDDe72tizc7v81seJI79jWM8uaNvQGufPxCEnOxvffjETXi2d0K6RDfwH9MCfCefl/RU+bnCPTninkQxjhvTF40d/43hMND7o0h6eTetj5qTRePmy5D/TT0pKQp8+fVC7dm0YGRnBxcUF+/fvBwDk5+dj9OjRcHR0hIGBAZydnbFs2TKF40eOHIkPPvgA369YjC6tGqODiz3WLl2AvLw8LPlmLjo2d0S3di7YtWNbsbH4355I+H3QHe0a2aB/Vw+cjTteYp0AcPLkSXTq1AkGBgaws7PD1KlTkZmZWeoxb4u3hIhIfHT0lS9XB7kvgPm2lfPesx8AemW/1bJ582YEBQXhzJkziIiIwCeffILdu3ejf//+mD17NpYuXQpfX18kJyfD0NAQKSkp6Ny5M8aOHYslS5bg5cuXmDlzJgYPHozDhw8DAD777DPExMRg165dsLGxwezZsxEfH4+WLVuWWIeWlhaWL18OBwcHJCYmYuLEiQgKCsLq1avlbV6+fIkt61biP2FroaWlhdnTxmPJN3MRumJ9sf5sbOvi9/ir6OfVDhM/nQ3vPv1Ry9gEfyTEAwDC5n+JwM+/Rr36DjA2NcXS+V/i0P5f8M3S1ZDVtUP4muX45KOB+PXYeZjWri3vd+3SBQj++jvoGxgi6JOPEfTJx9DVkyJ0xXq8zHyO6WN98eOmdRg1MUDpeU6aNAk5OTk4evQojIyMcPnyZdSq9epWVUFBAerVq4edO3fC0tISJ0+exLhx4yCTyTB48GB5H4cPH0ZPszrY9PM+XDh7GiGfTcHF+LNo094D2345hAN7d+Gb2YHw6OQFG9t68uOW/ucLBIWEooGTM7auX41po4Zj/8kEmNU2L1bnH3/8AW9vb3z99dfYsGED/v77b0yePBmTJ0/Gpk2bSvx3fFvV7FcXIiJSFzc3N3z++edwcnJCcHAwDAwMYGlpibFjx8LJyQlffPEFHj9+jEuXLgEA1qxZg9atW2P+/Plo0qQJWrVqhY0bNyImJgbXr1/H8+fPsWHDBixatAjdunWDq6srNm/ejPz8/FLrCAgIQJcuXeDo6Ij33nsPX3/9NXbu3KnQJi83F5/PXwIXt1Zo6uqGof5jcPrEUaX9aWtrw9LKGhKJBLWMTWBpZQ19AwP5/omfzoZHpy6wc3CEnlSKnVs3InDOPHTo0g0NGzfBF98tg1TfALsitir0O/mzOWjVzh1Nm7fAB0M/wrlTJ/D5/MVo2rwFWrf3xPu9+uLsyZKvXCQnJ+Pdd9+Fq6srGjRogN69e6NTp04AAF1dXcybNw/t2rWDo6MjRowYgZEjRxYbB3Nzc8z6agEcGjqh/9CP4NDQCVkvX2DMlE9h79gQoydPh66uHi6cPa1w3NCRY/F+z75o4OSMOfMXo5axMXbtUDy/1xYuXIjhw4cjICAATk5O8PT0xPLly7FlyxZkZWWVeH5vi1dYiIgqkq7hqysdlfXeKmjRooV8WVtbGxYWFnB1dZVvs7a2BgCkpaUBAOLj4xETEyO/KlDYrVu38PLlS+Tk5MDDw0O+3dzcHM7OzqXWERMTg/nz5+Py5cvIyMhAXl4esrKykJmZKX84V9/AEHYOjvJjLK1s8M+jv1U639eatWgpX76XlIi83Fy0bNdevk1XVxfNW7bG7RvXFY5zauoiX7awtIK+gSHq2TsobCt8K6moqVOn4pNPPsHBgwfx/vvvY+DAgQr/BmvXrsX333+PpKQk+VgWvTLl4uICLa1/r0VYWNZBI+em8nVtbW2Y1a6Nfx4/UjjOrXU7+bKOjg6atWhV7Pxei4+Px82bN/HDDz/ItwmCgIKCAiQmJqJp06ZKj3tbDCxEJD7VeWp+iUSl2zKVSVdXV2FdIpEobJNIJABe3a54/d8+ffpgwYIFxfqSyWS4ceOGyjUkJSWhZ8+emDBhAr7++muYm5vj+PHjGD16NHJzcwvVqvjjTCKRQFDhmZ3CDAz//fd53cfrcy20o9g2HR3FsVFa0/+PlTJjxoyBt7c39u3bh4MHDyI0NBSLFy/GlClTsHPnTkyfPh2LFy+Gh4cHjI2NsXDhQpw+rXilRNm/mY6SbaXVUbidMgUFBRg/fjymTp1abF/9+vXf2G958ZYQERGpRevWrfHXX3/BwcEBjRo1UngZGRmhUaNG0NXVxalTp+THPHnyBNevK/9NHgDOnTuHvLw8LF68GO7u7mjcuDEePKi4K1R2Dg2gq6eHC2f+rTk3Nxd/XUpAg0aN1f9+dnaYMGECoqKi8Omnn2L9+lfP4Bw7dgyenp6YOHEiWrVqhUaNGuHWrVtqe99LF87Jl/Py8nDljwQ4NnJS2vb1v3PRf+NGjRpBT09PbTUVxcBCRERqMWnSJPzzzz8YNmwYzpw5g9u3b+PgwYMYNWoU8vPzUatWLYwePRqfffYZfv/9d/z5558YOXKkwi2Moho2bIi8vDysWLECt2/fxtatW7F27doKOydDQyMM9h2FJf/5EidiDuHW9av4Kmgasl6+QP+hvmp9r4CAABw4cACJiYk4f/48Dh8+LL+90qhRI5w7dw4HDhzA9evXMXfuXJw9e1Zt7x2x+Xv8/r9fkXjzOuZ/PgMZ6en4YMhHStvOnDkTcXFxmDRpEhISEnDjxg3s3bsXU6ZMUVs9yvCWEBERqYWtrS1OnDiBmTNnwtvbG9nZ2bC3t0ePHj3koWThwoV4/vw5+vbtC2NjY3z66adIT08vsc+WLVtiyZIlWLBgAYKDg9GpUyeEhobCz8+vok4L02Z9iYKCAswJmIDMzOdo1qIl1myLhImZmVrfJz8/H5MmTcK9e/dgYmKCHj16YOnSpQCACRMmICEhAUOGDIFEIsGwYcMwceLEYn9WXl7TZn2JTWuW4epfl2Bn74iwDT+gtrmF0rYtWrRAbGws5syZg44dO0IQBDRs2BBDhgxRSy0lkQjlvcknMhkZGTA1NUV6ejpMTEzU2rfDrH1q7a+wO9/20ki/mqxZUzQ1FpqmqbGuquOhDplpSTBa/ephw8yJl2BkZV9lv6azsrKQmJgIR0dH6OtXsz/RFolL955Wdgkqa1HPTGN9qzIe9+8mo6enGyJ+O4omLq6ltn2bmkv7/6CsP795S4iIiIhEj4GFiIiIRI/PsBCR+FTnqfmJRKSuXX1cvPuksssoE34nICLxqc5T8xNRuTCwEBERkegxsBAREZHoMbAQkfjkvlS+TEQ1FgMLEYmQUMIyEdVUDCxEREQkegwsRERU5T1Ke4jxw/ujfeO66OBiX9nliJqbXW0c/q3qzRzNeViIiKjK2/r9avz9MBU7DxxFLWP1fjwLiYPKV1iOHj2KPn36wNbWFhKJBLt371bYL5FIlL4WLlxYYp/h4eFKj8nKylL5hIiIqOa5l3QHzVq0hL1jQ1hY1lHaJjc3t4KrInVSObBkZmbCzc0NK1euVLo/JSVF4bVx40ZIJBIMHDiw1H5NTEyKHcsPCiOiaisns+RXbpYKbV+Wra2KvLy8MGXKFAQEBKB27dqwtrbGunXrkJmZiY8//hjGxsZo2LBhsU8Lvnz5Mnr27IlatWrB2toavr6+ePTokXz/b7/9hg4dOsDMzAwWFhbo3bs3bt26Jd9/584dSCQSREVFoUuXLjA0NISbmxvi4uJKrNXHowUO7d+LX37eATe72pg7fSKAV7c+dm7diGmjhqN947pYv3wRAGDnlg3o9W4rtGlghb6d2+GXyB0K/bnZ1cZP2zZh8sghaO9kiw+6tMfF+DNITryN0R/2RvvGdeHbrzvu3kkssabcnBzM//wzdG3TBO0a2cDHowU2rFwi379kyRK4urrCyMgIdnZ2mDhxIp4/fy7fHx4eDjMzM/z6669wdnaGoaEhBg0ahMzMTGzevBkODg6oXbs2pkyZgvz8fPlxDg4O+G/YQsyaPAbuzvXwfpum2L5pXYl1AsDDlAf47JNR6NDcAZ1cG2DaqOG4fze51GMqg8q3hHx8fODj41PifhsbG4X1PXv2oEuXLmjQoEGp/UokkmLHElFNJSlhuRqZb1vyPqfuwIif/l1f2AjIfaG8rX0H4ONCzyOEuQIvHhdvF5KucombN29GUFAQzpw5g4iICHzyySfYvXs3+vfvj9mzZ2Pp0qXw9fVFcnIyDA0NkZKSgs6dO2Ps2LFYsmQJXr58iZkzZ2Lw4ME4fPgwgFe/9AYGBsLV1RWZmZn44osv0L9/fyQkJEBL69/foefMmYNFixbByckJc+bMwbBhw3Dz5k3o6BT/sfXDr4fxecAEGNUywcx5oZAW+mV3zZJvMXXmF/jsy/nQ0tbC7//7FQtCghH05Xy07+iFo4cO4MtPJ8NaVhfveHaUH7du2SLM+OIbzPjiPwibH4JZU8aiXn0HjJo0HbK69fDljCkInfsZVm/9WenYbd/4X8RG/w8LV2+ETd16SH1wHw8f3Jfv19LSwvLly+Hg4IDExERMnDgRQUFBWL16tbzNixcvsHz5cuzYsQPPnj3DgAEDMGDAAJiZmWH//v24ffs2Bg4ciA4dOmDIkCH//rv9dwVGT56OCYGzcDL2MBbNmw3Hhk7w6NSlWJ0vX77AmCF90fodD2z6aR+0dXSwfvkiTPQdhJ8PHoeunl5ZvlQqhEafYXn48CH27duHzZs3v7Ht8+fPYW9vj/z8fLRs2RJff/01WrVqVWL77OxsZGdny9czMjLUUjMRiYCugfJlqlBubm74/PPPAQDBwcH49ttvYWlpibFjxwIAvvjiC6xZswaXLl2Cu7s71qxZg9atW2P+/PnyPjZu3Ag7Oztcv34djRs3Lna1fcOGDbCyssLly5fRvHlz+fYZM2agV69eAIB58+bBxcUFN2/eRJMmTYrVaW5hCT09KfT19WFpZa2wr2e/Qeg/9CP5evCUsej34XAM8R8DAHAY1wh/XDiHLf9doRBY+g0eDu8+/QEAoyZOg2+/7hg39TO869UVADB81Hh8+enkEscu5cE91HdsiFbveEAikcC2Xn2F/QEBAfJlR0dHfP311/jkk08UAktubi7WrFmDhg0bAgAGDRqErVu34uHDh6hVqxaaNWuGLl26ICYmRiGwtGz7DkZPmv7q/Bo0QsLZU9j2/WqlgeW3PVHQ0tJCyMLlkEhe/XLw1eJV6ODigLNxx+HZ+b0Sz7GiaTSwbN68GcbGxhgwYECp7Zo0aYLw8HC4uroiIyMDy5Ytw7vvvouLFy/CyclJ6TGhoaGYN2+eJsomItK82Q9K3ifRVlz/7GYpbYvc2Q/4o/w1FdGiRQv5sra2NiwsLODq6irfZm39KhykpaUBAOLj4xETE4NatWoV6+vWrVto3Lgxbt26hblz5+LUqVN49OgRCgoKAADJyckKgaXwe8tkMvn7KAsspWnm1lJh/faN6xg4fKTCtpZt2+OHjWsVtjVu6iJfNre0AgA4NWkm32ZRxwrZ2Vl4/ixD6UO+/T4cjvHD+6Nv53Z416srOnX1VvjhHxMTg/nz5+Py5cvIyMhAXl4esrKykJmZCSMjIwCAoaGhPKwAr8bbwcFBYXytra3l4/9aizbvKKy7tXkH2zasKVYjAFz5IwF379yGRxM7he3Z2Vm4l1TyLa/KoNHAsnHjRowYMeKNz6K4u7vD3d1dvv7uu++idevWWLFiBZYvX670mODgYAQGBsrXMzIyYGdnp7QtEZHo6BlVfts30NXVVViXSCQK217/Rv46dBQUFKBPnz5YsGBBsb5eh44+ffrAzs4O69evh62tLQoKCtC8eXPk5OSU+N5F30cVBgbFx+N1f68JggBJkVuPOjrF319HaU3KJzZs6uqG/ScTcDzmEE4fj0XQxI/RvoMXFv93Mx7cS0b/nj0xYcIEfP311zA3N8fx48cxevRohQeD3zT+r7eVZVyKnvNrBQUFaOraEqHLiz/nUtvC4o39ViSNBZZjx47h2rVriIiIUPlYLS0ttGvXDjdu3CixjVQqhVQqfZsSiUisODV/ldS6dWtERkbCwcFB6bMmjx8/xpUrV/Df//4XHTu+uv1y/PjxCq2xgVNjXDh7Cn0GDZVvuxh/Bo5OjdX+XrWMTdCj7wD06DsA7/fsi4m+g5D+5AkuX0pAXl4eFi9eLH9uZ+fOnWp73z/On1VYv3T+LBwbKr9b0dTVDQd+2QVzS0vR/zm4xiaO27BhA9q0aQM3NzeVjxUEAQkJCfJETkQ1Dafmr4omTZqEf/75B8OGDcOZM2dw+/ZtHDx4EKNGjUJ+fj5q164NCwsLrFu3Djdv3sThw4cVrpRXBP/xU7Hnp+3YuXUjkhJvYcu6Vfj9f7/Af/wUtb7P1vWr8b89kUi8eR13bt9E9L49sLSyhrGpKerZOyIvLw8rVqzA7du3sXXrVqxdu/bNnZZRwrnT2LRmGe7cvokd4esRvW8Pho+aoLRtz/4fwszcAtNGj8D50ydxLzkJ5+JOYMGXs/Aw5b7SYyqLyoHl+fPnSEhIQEJCAgAgMTERCQkJSE7+90+gMjIy8NNPP2HMmDFK+/Dz80NwcLB8fd68eThw4ABu376NhIQEjB49GgkJCZgwQfkAExGR+Nja2uLEiRPIz8+Ht7c3mjdvjmnTpsHU1BRaWlrQ0tLCjh07EB8fj+bNm2P69OmlztGlCe/16IWZIaHYvHYFBnT1wM8/hGPe4pVo59FBre9jaGSETWuWYViv9zCi93t4cC8ZKzfvhJaWFpq4uGLJkiVYsGABmjdvjh9++AGhoaFqe2/fcZNx+dJFDOnRGeuWL8Knc7+RPyxclIGBITb9vA+yuvUQOM4P/d9rjy9nTEZ2VhaMahmrrSZ1kAiCoNKvL0eOHEGXLsWfNPb390d4eDgAYN26dQgICEBKSgpMTU2LtfXy8oKDg4O8/fTp0xEVFYXU1FSYmpqiVatWCAkJgYeHR5nrysjIgKmpKdLT02Fiot7LWg6zNDeF8Z1ve2mkX03WrCmaGgtN09RYV9XxUIfMtCQYrX710GXmxEswsrKvsl/TWVlZSExMhKOjI+eW0pBL955Wdgkqa1HPTCP9Ojg4YPDI8fhozCdq7/ttai7t/4Oy/vxW+RkWLy8vvCnjjBs3DuPGjStx/5EjRxTWly5diqVLl6paChEREdUQ/PBDIiIiEj1++CEREVE1cefOnSp5i6wseIWFiESoBkzNT0QqYWAhIvGphlPzq/j3DUTVijq+/hlYiIg06PXMpC9elPDhhUQ1wOuv/6Iz9aqCz7AQEWmQtrY2zMzM5J/3YmhoWOI06VQ+Ql7OmxuJTFZWlsb61tR4lKdmQRDw4sULpKWlwczMDNra2m8+qAQMLEQkPnlZyperKBsbGwAo9iF1pB5pT6rexzfovdTcrU5Njcfb1GxmZib//6C8GFiISHyEAuXLVZREIoFMJoOVlZXCh9uReoyJOlLZJajs90+9NNa3psajvDXr6uq+1ZWV1xhYiIgqiLa2tlq+cZOi+8/yK7sElWly1mNNjUdlz9TMh26JiIhI9BhYiIiISPQYWIiIiEj0GFiIiIhI9BhYiIiISPQYWIhIfHQNlS8TUY3FwEJERESix8BCREREosfAQkTiU82m5ieit8fAQkTiU82m5ieit8fAQkRERKLHwEJERESix8BCREREosfAQkRERKLHwEJERESix8BCREREosfAQkTiw6n5iagIBhYiIiISPQYWIiIiEj0GFiISn7xs5ctEVGMxsBCR+Aj5ypeJqMZiYCEiIiLRY2AhIiIi0WNgISIiItFTObAcPXoUffr0ga2tLSQSCXbv3q2wf+TIkZBIJAovd3f3N/YbGRmJZs2aQSqVolmzZti1a5eqpREREVE1pXJgyczMhJubG1auXFlimx49eiAlJUX+2r9/f6l9xsXFYciQIfD19cXFixfh6+uLwYMH4/Tp06qWR0RERNWQjqoH+Pj4wMfHp9Q2UqkUNjY2Ze4zLCwM3bp1Q3BwMAAgODgYsbGxCAsLw48//qhqiURERFTNaOQZliNHjsDKygqNGzfG2LFjkZaWVmr7uLg4dO/eXWGbt7c3Tp48WeIx2dnZyMjIUHgRUTXBqfmJqAiVr7C8iY+PDz788EPY29sjMTERc+fOxXvvvYf4+HhIpVKlx6SmpsLa2lphm7W1NVJTU0t8n9DQUMybN0+ttVPlcpi1r7JLqDHEPtbSnHRcM3m13PrraGTrmVZuQSKjyX+/O9/20ki/Yv+aI/FTe2AZMmSIfLl58+Zo27Yt7O3tsW/fPgwYMKDE4yQSicK6IAjFthUWHByMwMBA+XpGRgbs7OzeonIiIiISK7UHlqJkMhns7e1x48aNEtvY2NgUu5qSlpZW7KpLYVKptMQrNkRUtekhV2GZk/MTkcbnYXn8+DHu3r0LmUxWYhsPDw9ER0crbDt48CA8PT01XR4RiZA2CpQuE1HNpfIVlufPn+PmzZvy9cTERCQkJMDc3Bzm5uYICQnBwIEDIZPJcOfOHcyePRuWlpbo37+//Bg/Pz/UrVsXoaGhAIBp06ahU6dOWLBgAfr164c9e/bg0KFDOH78uBpOkYiIiKo6lQPLuXPn0KVLF/n66+dI/P39sWbNGvzxxx/YsmULnj59CplMhi5duiAiIgLGxsbyY5KTk6Gl9e/FHU9PT+zYsQOff/455s6di4YNGyIiIgLt27d/m3MjIiKiakLlwOLl5QVBEErcf+DAgTf2ceTIkWLbBg0ahEGDBqlaDhEREdUA/CwhIiIiEj0GFiIiIhI9BhYiIiISPQYWIhKdl9BTukxENRcDCxGJkKSEZSKqqRhYiIiISPQYWIhIdHQLTc1feJmIai4GFiISHZ1C0/HrcGp+IgIDCxEREVUBDCxEREQkegwsREREJHoMLERERCR6DCxEREQkegwsREREJHoMLEQkOpyan4iKYmAhIhHi1PxEpIiBhYiIiESPgYWIRIdT8xNRUQwsRCQ6nJqfiIpiYCEiIiLRY2AhIiIi0WNgISIiItFjYCEiIiLRY2AhIiIi0WNgISIiItFjYCEi0cmCrtJlIqq5GFiISHSEQt+aBH6bIiIwsBAREVEVwMBCRKKjizyly0RUczGwEJHo6CBf6TIR1VwMLERERCR6DCxEREQkegwsREREJHoqB5ajR4+iT58+sLW1hUQiwe7du+X7cnNzMXPmTLi6usLIyAi2trbw8/PDgwcPSu0zPDwcEomk2CsrK0vlEyIiIqLqR+XAkpmZCTc3N6xcubLYvhcvXuD8+fOYO3cuzp8/j6ioKFy/fh19+/Z9Y78mJiZISUlReOnr66taHhEREVVDOqoe4OPjAx8fH6X7TE1NER0drbBtxYoVeOedd5CcnIz69euX2K9EIoGNjY2q5RAREVENoPFnWNLT0yGRSGBmZlZqu+fPn8Pe3h716tVD7969ceHChVLbZ2dnIyMjQ+FFRNUDp+YnoqI0GliysrIwa9YsDB8+HCYmJiW2a9KkCcLDw7F37178+OOP0NfXx7vvvosbN26UeExoaChMTU3lLzs7O02cAhFVAk7NT0RFaew7QW5uLoYOHYqCggKsXr261Lbu7u746KOP4Obmho4dO2Lnzp1o3LgxVqxYUeIxwcHBSE9Pl7/u3r2r7lMgIiIikVD5GZayyM3NxeDBg5GYmIjDhw+XenVFGS0tLbRr167UKyxSqRRSqfRtSyUiESo6NX92JdZCROKg9issr8PKjRs3cOjQIVhYWKjchyAISEhIgEwmU3d5RFQFcGp+IipK5Sssz58/x82bN+XriYmJSEhIgLm5OWxtbTFo0CCcP38ev/76K/Lz85GamgoAMDc3h56eHgDAz88PdevWRWhoKABg3rx5cHd3h5OTEzIyMrB8+XIkJCRg1apV6jhHIiIiquJUDiznzp1Dly5d5OuBgYEAAH9/f4SEhGDv3r0AgJYtWyocFxMTAy8vLwBAcnIytLT+vbjz9OlTjBs3DqmpqTA1NUWrVq1w9OhRvPPOO6qWR0RERNWQyoHFy8sLgiCUuL+0fa8dOXJEYX3p0qVYunSpqqUQERFRDcG/FyQiIiLRY2AhIiIi0WNgISIiItFjYCEi0ckuNB1/NqfmJyIwsBCRCBUU+tZUwG9TRAQGFiIiIqoCGFiISHSKTs1PRMTAQkSiw6n5iagoBhYiIiISPQYWIiIiEj0GFiIiIhI9BhYiIiISPQYWIiIiEj0GFiIiIhI9BhYiEh1OzU9ERTGwEJHocGp+IiqK3wmIiIhI9BhYiEh0ONMtERXFwEJEosPPEiKiohhYiIiISPQYWIiIiEj0GFiIiIhI9BhYiIiISPQYWIiIiEj0GFiIiIhI9BhYiEh0cqCjdJmIai4GFiISnXxoK10mopqLgYWIiIhEj4GFiESHU/MTUVEMLEQkOpyan4iKYmAhIiIi0WNgISIiItFjYCEiIiLRUzmwHD16FH369IGtrS0kEgl2796tsF8QBISEhMDW1hYGBgbw8vLCX3/99cZ+IyMj0axZM0ilUjRr1gy7du1StTQiIiKqplQOLJmZmXBzc8PKlSuV7v/uu++wZMkSrFy5EmfPnoWNjQ26deuGZ8+eldhnXFwchgwZAl9fX1y8eBG+vr4YPHgwTp8+rWp5REREVA2pPIWkj48PfHx8lO4TBAFhYWGYM2cOBgwYAADYvHkzrK2tsX37dowfP17pcWFhYejWrRuCg4MBAMHBwYiNjUVYWBh+/PFHVUskIiKiakatz7AkJiYiNTUV3bt3l2+TSqXo3LkzTp48WeJxcXFxCscAgLe3d6nHZGdnIyMjQ+FFRNUDp+YnoqLU+p0gNTUVAGBtba2w3draGklJSaUep+yY1/0pExoainnz5r1FteLgMGtfZZdAIlWTvzaqy9T8VfHfsCrWXBVxnFWnkb8SkkgkCuuCIBTb9rbHBAcHIz09Xf66e/du+QsmIiIiUVPrFRYbGxsAr66YyGQy+fa0tLRiV1CKHlf0asqbjpFKpZBKpW9ZMRGJkXah6fi1OTU/EUHNV1gcHR1hY2OD6Oho+bacnBzExsbC09OzxOM8PDwUjgGAgwcPlnoMEVVfeoWm49fj1PxEhHJcYXn+/Dlu3rwpX09MTERCQgLMzc1Rv359BAQEYP78+XBycoKTkxPmz58PQ0NDDB8+XH6Mn58f6tati9DQUADAtGnT0KlTJyxYsAD9+vXDnj17cOjQIRw/flwNp0hERERVncqB5dy5c+jSpYt8PTAwEADg7++P8PBwBAUF4eXLl5g4cSKePHmC9u3b4+DBgzA2NpYfk5ycDC2tfy/ueHp6YseOHfj8888xd+5cNGzYEBEREWjfvv3bnBsRERFVExJBEITKLkIdMjIyYGpqivT0dJiYmKi1bz7NTVSxzHLSkGASAABomRGGp3pWlVsQEeHOt7000m9Zf37zs4SIiIhI9BhYiIiISPQYWIiIiEj0GFiISHRyC/09QC6n5iciMLAQkQjlFZqOP68KT81PROrDwEJERESix8BCRKLDqfmJqCgGFiISHU7NT0RFMbAQERGR6DGwEBERkegxsBAREZHoMbAQERGR6DGwEBERkegxsBAREZHoMbAQkehwan4iKoqBhYhEh1PzE1FRDCxEREQkegwsRCQ6WihQukxENRcDCxGJjhS5SpeJqOZiYCEiIiLRY2AhIiIi0WNgISIiItFjYCEiIiLRY2AhIiIi0WNgISIiItFjYCEi0eFMt0RUFAMLEYkOP0uIiIpiYCEiIiLRY2AhItHh1PxEVBQDCxGJDqfmJ6KiGFiIiIhI9BhYiIiISPQYWIiIiEj01B5YHBwcIJFIir0mTZqktP2RI0eUtr969aq6SyMiIqIqSu0THJw9exb5+fny9T///BPdunXDhx9+WOpx165dg4mJiXy9Tp066i6NiIiIqii1B5aiQePbb79Fw4YN0blz51KPs7KygpmZmbrLISIiompAo8+w5OTkYNu2bRg1ahQkEkmpbVu1agWZTIauXbsiJibmjX1nZ2cjIyND4UVE1QOn5ieiojQaWHbv3o2nT59i5MiRJbaRyWRYt24dIiMjERUVBWdnZ3Tt2hVHjx4tte/Q0FCYmprKX3Z2dmqunogqC6fmJ6KiJIIgCJrq3NvbG3p6evjll19UOq5Pnz6QSCTYu3dviW2ys7ORnZ0tX8/IyICdnR3S09MVnoVRB4dZ+9TaHxGVTpqTjmsmnwAAnDPWIFvPtJIrIqI73/bSSL8ZGRkwNTV9489vjf3qkpSUhEOHDiEqKkrlY93d3bFt27ZS20ilUkil0vKWR0QiJik0Hb+EU/MTETR4S2jTpk2wsrJCr16qJ7ILFy5AJpNpoCoiqgr0C03Hr8+p+YkIGrrCUlBQgE2bNsHf3x86OopvERwcjPv372PLli0AgLCwMDg4OMDFxUX+kG5kZCQiIyM1URoRERFVQRoJLIcOHUJycjJGjRpVbF9KSgqSk5Pl6zk5OZgxYwbu378PAwMDuLi4YN++fejZs6cmSiMiIqIqSCOBpXv37ijpWd7w8HCF9aCgIAQFBWmiDCIiIqom+FlCREREJHoMLERERCR6DCxEREQkegwsRCQ6nJqfiIpiYCEi0eHU/ERUFAMLERERiR4DCxGJDqfmJ6KiGFiISHQ4NT8RFcXAQkRERKLHwEJERESix8BCREREosfAQkRERKLHwEJERESix8BCREREosfAQkSik1foW1Mev00RERhYiEiEcqGrdJmIai4GFiIiIhI9BhYiEiGhhGUiqqkYWIhIdAyQo3SZiGouBhYiIiISPQYWIiIiEj0GFiIiIhI9BhYiIiISPQYWIiIiEj0GFiIiIhI9BhYiEh1OzU9ERfE7ARGJDqfmJ6KiGFiIiIhI9BhYiEiEODU/ESliYCEi0eHU/ERUFAMLERERiR4DCxEREYkeAwsRERGJntoDS0hICCQSicLLxsam1GNiY2PRpk0b6Ovro0GDBli7dq26yyIiIqIqTEcTnbq4uODQoUPydW1t7RLbJiYmomfPnhg7diy2bduGEydOYOLEiahTpw4GDhyoifKIiIioitFIYNHR0XnjVZXX1q5di/r16yMsLAwA0LRpU5w7dw6LFi1iYCEiIiIAGnqG5caNG7C1tYWjoyOGDh2K27dvl9g2Li4O3bt3V9jm7e2Nc+fOITc3t8TjsrOzkZGRofAiouohv9C3pnw+akdE0EBgad++PbZs2YIDBw5g/fr1SE1NhaenJx4/fqy0fWpqKqytrRW2WVtbIy8vD48ePSrxfUJDQ2Fqaip/2dnZqfU8iKjy5BSajj+HU/MTETQQWHx8fDBw4EC4urri/fffx759+wAAmzdvLvEYiUSisC4IgtLthQUHByM9PV3+unv3rhqqJyIiIjHSyDMshRkZGcHV1RU3btxQut/GxgapqakK29LS0qCjowMLC4sS+5VKpZBKpWqtlYiIiMRJ4zeHs7OzceXKFchkMqX7PTw8EB0drbDt4MGDaNu2LXR1eSmYqCYyQLbSZSKqudQeWGbMmIHY2FgkJibi9OnTGDRoEDIyMuDv7w/g1a0cPz8/efsJEyYgKSkJgYGBuHLlCjZu3IgNGzZgxowZ6i6NiIiIqii13xK6d+8ehg0bhkePHqFOnTpwd3fHqVOnYG9vDwBISUlBcnKyvL2joyP279+P6dOnY9WqVbC1tcXy5cv5J81EREQkp/bAsmPHjlL3h4eHF9vWuXNnnD9/Xt2lEBERUTXBCQ6IiIhI9BhYiIiISPQYWIiIiEj0GFiISHQ4NT8RFcXvBEQkOpyan4iKYmAhIiIi0WNgISIiItFjYCEi0eHU/ERUFAMLERERiR4DCxEREYkeAwsRERGJHgMLERERiR4DCxEREYkeAwsRERGJHgMLEYlOASRKl4mo5mJgISLRyYae0mUiqrkYWIiIiEj0GFiIiIhI9BhYiEh0ODU/ERXFwEJERESix8BCREREosfAQkRERKLHwEJERESix8BCREREosfAQkRERKLHwEJEosOp+YmoKAYWIhIdTs1PREUxsBAREZHoMbAQERGR6DGwEJHo6CNH6TIR1VwMLEQkOhIISpeJqOZiYCEiIiLRY2AhIiIi0VN7YAkNDUW7du1gbGwMKysrfPDBB7h27Vqpxxw5cgQSiaTY6+rVq+ouj4iIiKogtQeW2NhYTJo0CadOnUJ0dDTy8vLQvXt3ZGZmvvHYa9euISUlRf5ycnJSd3lERERUBemou8PffvtNYX3Tpk2wsrJCfHw8OnXqVOqxVlZWMDMzU3dJREREVMVp/BmW9PR0AIC5ufkb27Zq1QoymQxdu3ZFTExMqW2zs7ORkZGh8CKi6kEoNB2/wKn5iQgaDiyCICAwMBAdOnRA8+bNS2wnk8mwbt06REZGIioqCs7OzujatSuOHj1a4jGhoaEwNTWVv+zs7DRxCkRUCbIKTcefxan5iQgauCVU2OTJk3Hp0iUcP3681HbOzs5wdnaWr3t4eODu3btYtGhRibeRgoODERgYKF/PyMhgaCEiIqqmNHaFZcqUKdi7dy9iYmJQr149lY93d3fHjRs3StwvlUphYmKi8CIiIqLqSe2BRRAETJ48GVFRUTh8+DAcHR3L1c+FCxcgk8nUXB0RVQWcmp+IilL7LaFJkyZh+/bt2LNnD4yNjZGamgoAMDU1hYGBAYBXt3Pu37+PLVu2AADCwsLg4OAAFxcX5OTkYNu2bYiMjERkZKS6yyOiKoBT8xNRUWoPLGvWrAEAeHl5KWzftGkTRo4cCQBISUlBcnKyfF9OTg5mzJiB+/fvw8DAAC4uLti3bx969uyp7vKIiIioClJ7YBGEN/82FB4errAeFBSEoKAgdZdCRERE1QQ/S4iIiIhEj4GFiIiIRI+BhYiIiESPgYWIRIdT8xNRUQwsRCQ6nJqfiIpiYCEiIiLRY2AhIiIi0WNgISLRkRaajl/KqfmJCAwsRCRCWoWm49fi1PxEBAYWIiIiqgIYWIiIiEj0GFiIiIhI9BhYiIiISPQYWIiIiEj0GFiIiIhI9BhYiEh0XkKqdJmIai4GFiIiIhI9BhYiIiISPQYWIhIdTs1PREUxsBCR6HBqfiIqioGFiIiIRI+BhYiIiESPgYWIiIhEj4GFiIiIRI+BhYiIiESPgYWIiIhEj4GFiESHU/MTUVEMLERERCR6DCxEREQkegwsRCQ6eshVukxENRcDCxGJjjYKlC4TUc3FwEJERESix8BCREREoqexwLJ69Wo4OjpCX18fbdq0wbFjx0ptHxsbizZt2kBfXx8NGjTA2rVrNVUaERERVTEaCSwREREICAjAnDlzcOHCBXTs2BE+Pj5ITk5W2j4xMRE9e/ZEx44dceHCBcyePRtTp05FZGSkJsojIiKiKkYjgWXJkiUYPXo0xowZg6ZNmyIsLAx2dnZYs2aN0vZr165F/fr1ERYWhqZNm2LMmDEYNWoUFi1apInyiIiIqIrRUXeHOTk5iI+Px6xZsxS2d+/eHSdPnlR6TFxcHLp3766wzdvbGxs2bEBubi50dXWLHZOdnY3s7Gz5enp6OgAgIyPjbU+hmILsF2rvk4hKlp/zEhnZwqvl7JcoEPj/IFFl08TP18L9CoJQaju1B5ZHjx4hPz8f1tbWCtutra2Rmpqq9JjU1FSl7fPy8vDo0SPIZLJix4SGhmLevHnFttvZ2b1F9UQkBncBmMrXJlVeIUQkZxqm2f6fPXsGU1PTEverPbC8JpFIFNYFQSi27U3tlW1/LTg4GIGBgfL1goIC/PPPP7CwsCj1faj8MjIyYGdnh7t378LExKSyy6kROOYVi+NdsTjeFUus4y0IAp49ewZbW9tS26k9sFhaWkJbW7vY1ZS0tLRiV1Fes7GxUdpeR0cHFhYWSo+RSqWQShU/FM3MzKz8hVOZmZiYiOqLvSbgmFcsjnfF4nhXLDGOd2lXVl5T+0O3enp6aNOmDaKjoxW2R0dHw9PTU+kxHh4exdofPHgQbdu2Vfr8ChEREdUsGvkrocDAQHz//ffYuHEjrly5gunTpyM5ORkTJkwA8Op2jp+fn7z9hAkTkJSUhMDAQFy5cgUbN27Ehg0bMGPGDE2UR0RERFWMRp5hGTJkCB4/foyvvvoKKSkpaN68Ofbv3w97e3sAQEpKisKcLI6Ojti/fz+mT5+OVatWwdbWFsuXL8fAgQM1UR6Vk1QqxZdfflnsVhxpDse8YnG8KxbHu2JV9fGWCG/6OyIiIiKiSsbPEiIiIiLRY2AhIiIi0WNgISIiItFjYCEiIiLRY2AhIiIi0WNgoVI9efIEvr6+MDU1hampKXx9ffH06dM3HnflyhX07dsXpqamMDY2hru7u8KfspNy5R3v18aPHw+JRIKwsDCN1VidqDreubm5mDlzJlxdXWFkZARbW1v4+fnhwYMHFVd0FbN69Wo4OjpCX18fbdq0wbFjx0ptHxsbizZt2kBfXx8NGjTA2rVrK6jS6kGV8Y6KikK3bt1Qp04dmJiYwMPDAwcOHKjAalXDwEKlGj58OBISEvDbb7/ht99+Q0JCAnx9fUs95tatW+jQoQOaNGmCI0eO4OLFi5g7dy709fUrqOqqqzzj/dru3btx+vTpN34eB/1L1fF+8eIFzp8/j7lz5+L8+fOIiorC9evX0bdv3wqsuuqIiIhAQEAA5syZgwsXLqBjx47w8fEp8ZeXxMRE9OzZEx07dsSFCxcwe/ZsTJ06FZGRkRVcedWk6ngfPXoU3bp1w/79+xEfH48uXbqgT58+uHDhQgVXXkYCUQkuX74sABBOnTol3xYXFycAEK5evVricUOGDBE++uijiiixWinveAuCINy7d0+oW7eu8Oeffwr29vbC0qVLNVxt1fc2413YmTNnBABCUlKSJsqs0t555x1hwoQJCtuaNGkizJo1S2n7oKAgoUmTJgrbxo8fL7i7u2usxupE1fFWplmzZsK8efPUXZpa8AoLlSguLg6mpqZo3769fJu7uztMTU1x8uRJpccUFBRg3759aNy4Mby9vWFlZYX27dtj9+7dFVR11VWe8QZejbmvry8+++wzuLi4VESp1UJ5x7uo9PR0SCQSfvhqETk5OYiPj0f37t0Vtnfv3r3E8Y2LiyvW3tvbG+fOnUNubq7Gaq0OyjPeRRUUFODZs2cwNzfXRIlvjYGFSpSamgorK6ti262srIp9uvZraWlpeP78Ob799lv06NEDBw8eRP/+/TFgwADExsZquuQqrTzjDQALFiyAjo4Opk6dqsnyqp3yjndhWVlZmDVrFoYPHy66T7+tbI8ePUJ+fj6sra0VtltbW5c4vqmpqUrb5+Xl4dGjRxqrtTooz3gXtXjxYmRmZmLw4MGaKPGtMbDUQCEhIZBIJKW+zp07BwCQSCTFjhcEQel24FVCB4B+/fph+vTpaNmyJWbNmoXevXvX2IfnNDne8fHxWLZsGcLDw0tsU9NocrwLy83NxdChQ1FQUIDVq1er/Tyqi6Jj+abxVdZe2XZSTtXxfu3HH39ESEgIIiIilAZ5MdDIhx+SuE2ePBlDhw4ttY2DgwMuXbqEhw8fFtv3999/F0vxr1laWkJHRwfNmjVT2N60aVMcP368/EVXYZoc72PHjiEtLQ3169eXb8vPz8enn36KsLAw3Llz561qr4o0Od6v5ebmYvDgwUhMTMThw4d5dUUJS0tLaGtrF/vtPi0trcTxtbGxUdpeR0cHFhYWGqu1OijPeL8WERGB0aNH46effsL777+vyTLfCgNLDWRpaQlLS8s3tvPw8EB6ejrOnDmDd955BwBw+vRppKenw9PTU+kxenp6aNeuHa5du6aw/fr16/JP665pNDnevr6+xb7BeHt7w9fXFx9//PHbF18FaXK8gX/Dyo0bNxATE8MfpCXQ09NDmzZtEB0djf79+8u3R0dHo1+/fkqP8fDwwC+//KKw7eDBg2jbti10dXU1Wm9VV57xBl5dWRk1ahR+/PFH9OrVqyJKLb/KfOKXxK9Hjx5CixYthLi4OCEuLk5wdXUVevfurdDG2dlZiIqKkq9HRUUJurq6wrp164QbN24IK1asELS1tYVjx45VdPlVTnnGuyj+lVDZqTreubm5Qt++fYV69eoJCQkJQkpKivyVnZ1dGacgajt27BB0dXWFDRs2CJcvXxYCAgIEIyMj4c6dO4IgCMKsWbMEX19fefvbt28LhoaGwvTp04XLly8LGzZsEHR1dYWff/65sk6hSlF1vLdv3y7o6OgIq1atUvhafvr0aWWdQqkYWKhUjx8/FkaMGCEYGxsLxsbGwogRI4QnT54otAEgbNq0SWHbhg0bhEaNGgn6+vqCm5ubsHv37oorugor73gXxsBSdqqOd2JiogBA6SsmJqbC668KVq1aJdjb2wt6enpC69athdjYWPk+f39/oXPnzgrtjxw5IrRq1UrQ09MTHBwchDVr1lRwxVWbKuPduXNnpV/L/v7+FV94GUgE4f+faCIiIiISKf6VEBEREYkeAwsRERGJHgMLERERiR4DCxEREYkeAwsRERGJHgMLERERiR4DCxEREYkeAwsRERGJHgMLERERiR4DCxEREYkeAwsRERGJ3v8BFWHaHvjaQWgAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def plt_parameter_distribution(para_all, para_default, title, bins=20):\n",
+    "    plt.hist(para_all, bins=bins, color='C0')\n",
+    "    plt.axvline(para_default, c='k', label='control run')\n",
+    "    plt.axvline(np.median(para_all), c='C1', label='median from sample')\n",
+    "    plt.axvline(np.mean(para_all), c='C1', ls='--', label='mean from sample')\n",
+    "    plt.title(title)\n",
+    "    plt.legend()\n",
+    "    plt.show()\n",
+    "\n",
+    "plt_parameter_distribution(prcp_fac_all,\n",
+    "                           prcp_fac_default,\n",
+    "                           'prcp_fac',\n",
+    "                           bins=20)\n",
+    "\n",
+    "plt_parameter_distribution(melt_f_all,\n",
+    "                           melt_f_default,\n",
+    "                           'melt_f',\n",
+    "                           bins=20)\n",
+    "\n",
+    "plt_parameter_distribution(temp_bias_all,\n",
+    "                           temp_bias_default,\n",
+    "                           'temp_bias',\n",
+    "                           bins=20)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3ed0da3-d416-4a6f-976b-af255cbdd10b",
+   "metadata": {},
+   "source": [
+    "## pick one year and look at distribution of resulting mb values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bb81de8-4fcb-4f62-931c-01c60b271067",
+   "metadata": {},
+   "source": [
+    "Here we visualize the uncertainty for the specific mass balance for the period 1980 to 2020 as defined by the MCS sample."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "4779f043-b56c-4c58-8399-b67eb60fe563",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fls = gdir.read_pickle('inversion_flowlines')\n",
+    "years = np.arange(1980, 2020)\n",
+    "\n",
+    "# get control run (= current default OGGM calibration)\n",
+    "mb_mod = MonthlyTIModel(gdir, settings_filesuffix='')\n",
+    "specific_mb_default = mb_mod.get_specific_mb(fls=fls, year=years)\n",
+    "\n",
+    "# now get values from MCS sample\n",
+    "specific_mb_all = []\n",
+    "for i in range(param_values.shape[0]):\n",
+    "    mb_mod = MonthlyTIModel(gdir, settings_filesuffix=f'_{i}')\n",
+    "    specific_mb_all.append(mb_mod.get_specific_mb(fls=fls, year=years))\n",
+    "specific_mb_all = np.array(specific_mb_all)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "747f1282-2ef5-4c18-9e3c-b2b30f7bf8df",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlcAAAGxCAYAAABPzpOGAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOydd3gUVReH363Jbja9B0ISQu9NKSod6VgBAamKYkME7IggCoKCBSzYABHFCp8o0qRXqUqTmpAE0nvdbJnvj7hLNrsJCaRs4L7Ps8+T3Hvmzp3Z2ZnfnHvuuTJJkiQEAoFAIBAIBJWCvKY7IBAIBAKBQHAzIcSVQCAQCAQCQSUixJVAIBAIBAJBJSLElUAgEAgEAkElIsSVQCAQCAQCQSUixJVAIBAIBAJBJSLElUAgEAgEAkElIsSVQCAQCAQCQSUixJVAIBAIBAJBJSLE1S3O8uXLkclkpX62b99e012sFMLDwxk3blyN7Hvx4sU0aNAAtVqNTCYjIyPDod3evXuZNWuWw/rw8HAGDRpUtR2t5axfv55Zs2bdUBvjxo0jPDz8urYt6/vr3r073bt3v6G+CRxz5coVZs2axbFjxyq9bcv9MTo6utLbBvv7UlnHMm7cOHQ63XXvq3v37shkMurXr4+jhVl27txpve8vX77crv6ff/5h/PjxRERE4Orqik6no127dixYsIC0tDSrncFgYOnSpdx22234+Pig1WoJCwvjnnvuYc2aNdfd/9qGEFcCAJYtW8a+ffvsPu3atavprtVqjh07xuTJk+nRowdbt25l3759uLu7O7Tdu3cvs2fPLlV8Ccpm/fr1zJ49+4baeO211677AVDW9/fxxx/z8ccf31DfBI65cuUKs2fPrhJxVdWsWbOG1157zfp/VR+Lu7s7UVFRbN261a7uq6++wsPDw+F2n3/+Oe3bt+fgwYM8//zzbNiwgTVr1jB06FA+/fRTHnnkEavt6NGjeeaZZ+jRowfffPMN69atY8aMGSiVSjZu3Fglx+WMKGu6AwLnoEWLFnTo0KGmu3HTcfLkSQAmTpzI7bffXsO9uTnJy8tDq9VWSluRkZGV0k5JmjVrViXt3ozk5+fj6uqKTCar6a5UOW3btq3W/dWrVw93d3e++uorevXqZS3Pzs7mxx9/ZNSoUXz++ec22+zbt48nnniCPn36sHbtWlxcXKx1ffr0Ydq0aWzYsAGAqKgovv/+e2bOnGnzotOrVy8mTpyI2Wyu4iN0HoTnSlAuVq9ejUwmY8mSJTblr7/+OgqFgs2bN1vLZs+eTceOHfHx8cHDw4N27drx5Zdf2rmiLUNdv/32G23btkWj0dC0aVN+++03oMgl37RpU9zc3Lj99ts5dOiQzfYWN/nJkyfp1asXbm5u+Pv78/TTT5OXl3fNY8rKymL69OlERESgVqupU6cOU6ZMITc3t1zn5KuvvqJ169a4urri4+PDfffdx+nTp6313bt35+GHHwagY8eOyGSyUocmZ82axfPPPw9AREREqcOyGzZsoF27dmg0Gpo0acJXX31l11ZCQgKPP/44devWRa1WExERwezZszEajdc8JplM5nBoreTwhWW4ZNu2bTzxxBP4+fnh6+vL/fffz5UrV+y2//bbb+ncuTM6nQ6dTkebNm348ssvbWy2bNlCr1698PDwQKvVcscdd/Dnn3/anSeZTMaRI0d48MEH8fb2JjIyknHjxvHRRx9Zj8HysQznfPTRR3Tt2pWAgADc3Nxo2bIlCxYswGAw2LTvaFhQJpPx9NNPs3LlSpo2bYpWq6V169bW69TSr7K+P0fDgoWFhbz55ps0adIEFxcX/P39GT9+PMnJyTZ2W7dupXv37vj6+qLRaKhXrx4PPPDANa9xvV7PtGnTCAoKQqvV0rVrVw4fPuxwiLw810x0dDQymYx3332XRYsWERERgU6no3Pnzuzfv99u/4cOHWLIkCH4+Pjg6upK27Zt+eGHH2xsLNfRpk2bmDBhAv7+/mi1WvR6PefPn2f8+PE0bNgQrVZLnTp1GDx4MMePH7duv337dm677TYAxo8fbz3vxa/h8vQDYP/+/dxxxx24uroSEhLCyy+/bHd9OOL3339HJpNx8OBBa9nPP/+MTCZj4MCBNratWrXigQcesP5f/Lsoz7EAnD9/ngEDBqDT6QgNDWXatGno9fpr9tPChAkT+OWXX2w8rKtXrwbgoYcesrOfO3cuMpmMzz77zEZYWVCr1QwZMgSA1NRUAIKDgx3uWy6/hSSHJLilWbZsmQRI+/fvlwwGg83HaDTa2E6aNElSq9XSwYMHJUmSpD///FOSy+XSjBkzbOzGjRsnffnll9LmzZulzZs3S3PmzJE0Go00e/ZsG7uwsDCpbt26UosWLaTvvvtOWr9+vdSxY0dJpVJJM2fOlO644w7pl19+kdasWSM1atRICgwMlPLy8qzbjx07VlKr1VK9evWkt956S9q0aZM0a9YsSalUSoMGDbLb19ixY63/5+bmSm3atJH8/PykRYsWSVu2bJE++OADydPTU+rZs6dkNpvLPG9z586VAGnEiBHS77//Ln399ddS/fr1JU9PT+ns2bOSJEnSyZMnpRkzZkiAtGzZMmnfvn3S+fPnHbYXGxsrPfPMMxIg/fLLL9K+ffukffv2SZmZmTbnqlmzZtLXX38tbdy4URo6dKgESDt27LC2Ex8fL4WGhkphYWHS0qVLpS1btkhz5syRXFxcpHHjxpV5TJIkSYD0+uuv25WXPH+W66Z+/frSM888I23cuFH64osvJG9vb6lHjx4227722msSIN1///3Sjz/+KG3atElatGiR9Nprr1ltVq5cKclkMunee++VfvnlF2ndunXSoEGDJIVCIW3ZssVq9/rrr0uAFBYWJr344ovS5s2bpbVr10rnz5+XHnzwQQmwnrt9+/ZJBQUFkiRJ0nPPPSd98skn0oYNG6StW7dK7733nuTn5yeNHz/epq9jx46VwsLC7M5JeHi4dPvtt0s//PCDtH79eql79+6SUqmULly4UK7vr1u3blK3bt2sbZpMJqlfv36Sm5ubNHv2bGnz5s3SF198IdWpU0dq1qyZ9TqPioqSXF1dpT59+khr166Vtm/fLq1atUoaPXq0lJ6eXuZ3OWLECEkul0svvfSStGnTJun999+XQkNDJU9PT5vvsrzXTFRUlPVc9OvXT1q7dq20du1aqWXLlpK3t7eUkZFhtd26daukVqulu+66S/r++++lDRs2SOPGjbP+FkpeR3Xq1JEee+wx6Y8//pB++uknyWg0Sjt27JCmTZsm/fTTT9KOHTukNWvWSPfee6+k0Wikf//9V5IkScrMzLS2MWPGDOt5j42NrVA/Tp48KWm1WqlZs2bSd999J/3vf/+T+vbtK9WrV08CpKioqFLPc3Z2tqRSqaS5c+dayyZNmiRpNBrJzc1NKiwslCRJkhITEyWZTCZ9/PHHVrviv6trHYvlfte0aVPp3XfflbZs2SLNnDlTkslkdvdWR3Tr1k1q3ry5lJWVJbm5udn0o2PHjtKYMWOkgwcP2pwbo9EoabVaqWPHjtdsX5IkKScnR/Ly8pKCgoKkpUuXlnnebnaEuLrFsfyYHX0UCoWNbUFBgdS2bVspIiJCOnXqlBQYGCh169bNToQVx2QySQaDQXrjjTckX19fG9ESFhYmaTQaKS4uzlp27NgxCZCCg4Ol3Nxca/natWslQPr111+tZWPHjpUA6YMPPrDZ51tvvSUB0u7du232VfyBMm/ePEkul1uFooWffvpJAqT169eXekzp6emSRqORBgwYYFMeExMjubi4SCNHjrSWWc5vyf044p133in1Rh4WFia5urpKly5dspbl5+dLPj4+0uOPP24te/zxxyWdTmdjJ0mS9O6770qAdPLkyTL7UFFx9eSTT9rYLViwQAKk+Ph4SZIk6eLFi5JCoZBGjRpV6j5zc3MlHx8fafDgwTblJpNJat26tXT77bdbyyziaubMmXbtPPXUU1J53hct1+TXX38tKRQKKS0tzVpXmrgKDAyUsrKyrGUJCQmSXC6X5s2bZy0r6/srKa6+++47CZB+/vlnGzvLw83y4LNcj8eOHbvmcRXn5MmTEiC9+OKLNuWW/Rb/Lst7zVjEVcuWLW1+83/99ZcESN999521rEmTJlLbtm0lg8Fg0+agQYOk4OBgyWQySZJ09ToaM2bMNY/JaDRKhYWFUsOGDaXnnnvOWl5SEBSnvP0YPny4pNFopISEBJv9NWnS5JriSpIk6c4775R69uxp/b9BgwbS888/L8nlcuvLz6pVqyTA+vIlSfa/q7KOxXK/++GHH2zKBwwYIDVu3LjM/knSVXFlaatDhw6SJF29VrZv3263/4SEBAmQHnrooWu2b+H333+X/Pz8rM8RX19faejQoTb37luBW8hHJyiLr7/+moMHD9p8Dhw4YGPj4uLCDz/8QGpqKu3atUOSJL777jsUCoWN3datW+nduzeenp4oFApUKhUzZ84kNTWVpKQkG9s2bdpQp04d6/9NmzYFioZRisfRWMovXbpk1/dRo0bZ/D9y5EgAtm3bVurx/vbbb7Ro0YI2bdpgNBqtn759+15zluS+ffvIz8+3G1oJDQ2lZ8+edkNZlUWbNm2oV6+e9X9XV1caNWpkc05+++03evToQUhIiM1x9e/fH4AdO3ZUap8swwEWWrVqBVz9njZv3ozJZOKpp54qtY29e/eSlpbG2LFjbfpsNpvp168fBw8etBuqLT60Uh6OHj3KkCFD8PX1tV6TY8aMwWQycfbs2Wtu36NHD5uJCIGBgQQEBDi8HsvDb7/9hpeXF4MHD7Y55jZt2hAUFGS9/tq0aYNareaxxx5jxYoVXLx4sVztW77nYcOG2ZQ/+OCDKJW2obYVvWYGDhxo85sv+Z2fP3+ef//91/q7LN7mgAEDiI+P58yZMzZtOvo+jUYjc+fOpVmzZqjVapRKJWq1mnPnztkMv5dGRfqxbds2evXqRWBgoHV7hULB8OHDr7kfKIop2rNnD/n5+Vy6dInz58/z0EMP0aZNG2vIxJYtW6hXrx4NGzYsV5uOkMlkDB482KasVatWFb4OJ0yYwKFDhzh+/DhffvklkZGRdO3a9br7VZwBAwYQExPDmjVrmD59Os2bN2ft2rUMGTKEp59+ulL2URsQ4koAFImXDh062Hzat29vZ9egQQPuuusuCgoKGDVqlN3Y+l9//cXdd98NFM0w2bNnDwcPHuTVV18FioJVi+Pj42Pzv1qtLrO8oKDAplypVOLr62tTFhQUBFwd/3dEYmIi//zzDyqVyubj7u6OJEmkpKSUum1ZcQUhISFl7vdGKHmcUCR4i5/TxMRE1q1bZ3dczZs3ByjzuCqjT5aYDEufLPFDdevWLbWNxMREoOjBX7Lf8+fPR5Ikm6neUHpMhyNiYmK46667uHz5Mh988AG7du3i4MGD1hitktekI8pz7itCYmIiGRkZqNVqu2NOSEiwfk+RkZFs2bKFgIAAnnrqKSIjI4mMjOSDDz4os33LNVhcLIDj30tFr5lrfeeW73P69Ol2bT755JMO23T0fU6dOpXXXnuNe++9l3Xr1nHgwAEOHjxI69aty3XeK9KP1NRU632jOI7KHNG7d2/0ej27d+9m8+bN+Pn50bZtW3r37s2WLVsA+PPPP+ndu3e52isNrVaLq6urTZmLi4vdffFadO3alYYNG7J06VJWrlzJhAkTHE4g8PPzQ6vVEhUVVaH2NRoN9957L++88w47duzg/PnzNGvWjI8++sg6yedmR8wWFFSIL774gt9//53bb7+dJUuWMHz4cDp27GitX716NSqVit9++83mJrB27doq6Y/RaCQ1NdXmhp+QkAA4fiBa8PPzQ6PROAwIt9SXhqXd+Ph4u7orV66UuW1V4+fnR6tWrXjrrbcc1oeEhJS5vYuLi8Pg2OsVjP7+/gDExcURGhrq0MZyvhYvXkynTp0c2pQUCRWZSbZ27Vpyc3P55ZdfCAsLs5bX5NR9ywQAyyyrkhT3kt11113cddddmEwmDh06xOLFi5kyZQqBgYEOA5Dh6jWamJho4xm2/F5K9uVGrhlHxwbw8ssvc//99zu0ady4sc3/jr7Pb775hjFjxjB37lyb8pSUFLy8vCq1H76+vtb7RnEclTmiY8eO6HQ6tmzZQnR0NL169UImk9GrVy8WLlzIwYMHiYmJuWFxVZmMHz+eGTNmIJPJGDt2rEMbhUJBr169+OOPP4iLiyvzJaks6tWrx2OPPcaUKVM4efKkVbjfzAhxJSg3x48fZ/LkyYwZM4bPP/+cLl26MHz4cI4ePYq3tzdQdJNUKpU2wwb5+fmsXLmyyvq1atUqJk+ebP3/22+/BSgzaeOgQYOYO3cuvr6+REREVGh/nTt3RqPR8M033zB06FBreVxcHFu3buXBBx+s2AH8R0kPwPUwaNAg1q9fT2RkpPU7qQjh4eH8888/NmVbt24lJyfnuvpz9913o1Ao+OSTT+jcubNDmzvuuAMvLy9OnTp1Q8MGxc+fRqOxllse3MVnOkmSZDfl/EapyPc3aNAgVq9ejclksnk5KQuFQkHHjh1p0qQJq1at4siRI6WKK8sQz/fff2+Tq+6nn36ymzV6o9dMSRo3bkzDhg35+++/7YRRRZDJZHaz037//XcuX75MgwYNrGWlnfeK9KNHjx78+uuvJCYmWoW8yWTi+++/L1dfVSoVXbt2ZfPmzcTGxvL2228DRcJYqVRaRUzx9AeOqIx7QHkZO3YsBw4coGnTpjYCvCQvv/wy69evZ+LEifzvf/+zjiJYMBgMbNiwgcGDB5OdnY1MJnOY7NQylFtRsV5bEeJKAMCJEyccTtWPjIzE39+f3Nxchg0bRkREBB9//DFqtZoffviBdu3aMX78eKtnauDAgSxatIiRI0fy2GOPkZqayrvvvutwCm9loFarWbhwITk5Odx2223s3buXN998k/79+3PnnXeWut2UKVP4+eef6dq1K8899xytWrXCbDYTExPDpk2bmDZtWqkPPS8vL1577TVeeeUVxowZw4gRI0hNTWX27Nm4urry+uuvX9extGzZEoAPPviAsWPHolKpaNy4calJRx3xxhtvsHnzZrp06cLkyZNp3LgxBQUFREdHs379ej799NMy3z5Hjx7Na6+9xsyZM+nWrRunTp1iyZIleHp6XtcxhYeH88orrzBnzhzy8/MZMWIEnp6enDp1ipSUFGbPno1Op2Px4sWMHTuWtLQ0HnzwQQICAkhOTubvv/8mOTmZTz755Jr7spy/+fPn079/fxQKBa1ataJPnz6o1WpGjBjBCy+8QEFBAZ988gnp6enXdUzX2n95vr+HHnqIVatWMWDAAJ599lluv/12VCoVcXFxbNu2jXvuuYf77ruPTz/9lK1btzJw4EDq1atHQUGB1dtalhekefPmjBgxgoULF6JQKOjZsycnT55k4cKFeHp62kyJv9FrxhFLly6lf//+9O3bl3HjxlGnTh3S0tI4ffo0R44c4ccff7xmG4MGDWL58uU0adKEVq1acfjwYd555x27vkRGRqLRaFi1ahVNmzZFp9MREhJCSEhIufsxY8YMfv31V3r27MnMmTPRarV89NFH5U7LAkVxV9OmTQOufjcajYYuXbqwadMmWrVqRUBAQJltlHUslU1ISEi5RhQ6d+7MJ598wpNPPkn79u154oknaN68OQaDgaNHj/LZZ5/RokULBg8ezJkzZ+jbty8PPfQQ3bp1Izg4mPT0dH7//Xc+++wzunfvTpcuXSr9WJySmo2nF9Q0Zc0WBKTPP/9ckiRJevjhhyWtVms32+zHH3+UAOm9996zln311VdS48aNJRcXF6l+/frSvHnzpC+//NJu1k1YWJg0cOBAuz4B0lNPPWVTZpmp9M4771jLxo4dK7m5uUn//POP1L17d0mj0Ug+Pj7SE088IeXk5NhsX3JWjiQVTRueMWOG1LhxY0mtVkuenp5Sy5Ytpeeee85m1lBpfPHFF1KrVq2s295zzz1256ciswUlSZJefvllKSQkRJLL5RIgbdu2zdp/R+eq5Cw0SZKk5ORkafLkyVJERISkUqkkHx8fqX379tKrr75qd15KotfrpRdeeEEKDQ2VNBqN1K1bN+nYsWOlzhYseVzbtm2z6beFr7/+WrrtttskV1dXSafTSW3btrWbEbVjxw5p4MCBko+Pj6RSqaQ6depIAwcOlH788UerjWW2YHJyssO+P/roo5K/v78kk8lsrrd169ZJrVu3llxdXaU6depIzz//vPTHH3/Y9bW02YIlr0dJcnxNlfb9OfqeDAaD9O6771r7pdPppCZNmkiPP/64dO7cOUmSJGnfvn3SfffdJ4WFhUkuLi6Sr6+v1K1bt3LNvCooKJCmTp0qBQQESK6urlKnTp2kffv2SZ6enjaz7SSpfNeMo99g8XNUcpbp33//LQ0bNkwKCAiQVCqVFBQUJPXs2VP69NNPrTZl/T7S09OlRx55RAoICJC0Wq105513Srt27XJ4Lr/77jupSZMmkkqlsutLefohSZK0Z88eqVOnTpKLi4sUFBQkPf/889Jnn31WrtmClv0AUsOGDW3KLbOXp06dareNo2uotGOx3O9KYvlNXIviswVLo6zZiseOHZPGjh0r1atXT1Kr1ZKbm5vUtm1baebMmVJSUpIkSUXf2Ztvvin17NlTqlOnjtWuTZs20ptvvmmTSudmRyZJDhYZEghqAePGjeOnn3667iErgeBWY+/evdxxxx2sWrXKOqtWIBBUPmJYUCAQCG5CNm/ezL59+2jfvj0ajYa///6bt99+m4YNG5Ya4C0QCCoHIa4EAoHgJsTDw4NNmzbx/vvvk52djZ+fH/3792fevHl20/kFAkHlIoYFBQKBQCAQCCoRkURUIBAIBAKBoBIR4kogEAgEAoGgEhHiSiAQCAQCgaASEQHtVYDZbObKlSu4u7tXaJkOgUAgEAgENYckSWRnZxMSEmKTbLeiCHFVBVy5cqXUddQEAoFAIBA4N7Gxsde9liIIcVUlWJa7iI2NxcPDo4Z7IxAIBAKBoDxkZWURGhpaoWXHHCHEVRVgGQr08PAQ4kogEAgEglrGjYb0iIB2gUAgEAgEgkpEiCuBQCAQCASCSkSIK4FAIBAIBIJKRMRcCQQCwS2MyWTCYDDUdDcEgmpDpVKhUCiqdB9CXAkEAsEtSk5ODnFxcYglZgW3EjKZjLp166LT6apsH0JcCQQCwS2IyWQiLi4OrVaLv7+/SHgsuCWQJInk5GTi4uJo2LBhlXmwhLgSCASCWxCDwYAkSfj7+6PRaGq6OwJBteHv7090dDQGg6HKxJUIaBcIBIJbGOGxEtxqVMc1L8SVQCAQCAQCQSUihgUFAoFAYKWwsBCTyVRt+1MoFKjV6mrbn0BQHQhxJRAIBAKgSFidO3euWmcPymQyGjZsKATWLU54eDhTpkxhypQpNd2VSkEMCwoEAoEAKJpBWN1pGSRJqlZPWU3QvXt3ZDIZb7/9tl3dgAEDkMlkzJo1y6b8/PnzjB8/nrp16+Li4kJERAQjRozg0KFDVptt27bRo0cPfHx80Gq1NGzYkLFjx2I0Gqv6kATXQIgrgUAgENRaCgsLa7oL5SI0NJRly5bZlF25coWtW7cSHBxsU37o0CHat2/P2bNnWbp0KadOnWLNmjU0adKEadOmAXDy5En69+/Pbbfdxs6dOzl+/DiLFy9GpVJhNpur7bgEjhHiSiAQCGoBycnJ5OXl1XQ3apzu3bvz9NNPM3XqVPz8/OjTpw8AixYtomXLlri5uREaGsqTTz5JTk6Odbvly5fj5eXFxo0badq0KTqdjn79+hEfH2+1MRqNTJ48GS8vL3x9fXnxxRcZO3Ys9957r9VGkiQWLFhA/fr10Wg0tG7dmp9++uma/R40aBCpqans2bPHpk933303AQEBNu2PGzeOhg0bsmvXLgYOHEhkZCRt2rTh9ddf53//+x8AmzdvJjg4mAULFtCiRQsiIyPp168fX3zxRZlDrLNmzaJevXq4uLgQEhLC5MmTrXXffPMNHTp0wN3dnaCgIEaOHElSUpK1fvv27chkMjZu3Ejbtm3RaDT07NmTpKQk/vjjD5o2bYqHhwcjRoywuVYt39nTTz9tPbczZswo00uamZnJY489RkBAAB4eHvTs2ZO///77mufZWRDiSiAQCGoBKSkpZGVl1XQ3nIIVK1agVCrZs2cPS5cuBUAul/Phhx9y4sQJVqxYwdatW3nhhRdstsvLy+Pdd99l5cqV7Ny5k5iYGKZPn26tnz9/PqtWrWLZsmXs2bOHrKws1q5da9PGjBkzWLZsGZ988gknT57kueee4+GHH2bHjh1l9lmtVjNq1Cgb79Xy5cuZMGGCjd2xY8c4efIk06ZNQy63f0R7eXkBEBQURHx8PDt37rzm+bLw008/8d5777F06VLOnTvH2rVradmypbW+sLCQOXPm8Pfff7N27VqioqIYN26cXTuzZs1iyZIl7N27l9jYWIYNG8b777/Pt99+y++//87mzZtZvHixzTaW7+zAgQN8+OGHvPfee3zxxRcO+ylJEgMHDiQhIYH169dz+PBh2rVrR69evUhLSyv38dYkIqBdIBAInBxLXJIY7imiQYMGLFiwwKaseCB0REQEc+bM4YknnuDjjz+2lhsMBj799FMiIyMBePrpp3njjTes9YsXL+bll1/mvvvuA2DJkiWsX7/eWp+bm8uiRYvYunUrnTt3BqB+/frs3r2bpUuX0q1btzL7/cgjj3DnnXfywQcfcPjwYTIzMxk4cKBNvNW5c+cAaNKkSZltDR06lI0bN9KtWzeCgoLo1KkTvXr1YsyYMXh4eDjcJiYmhqCgIHr37o1KpaJevXrcfvvt1vriQq9+/fp8+OGH3H777eTk5NgsFfPmm29yxx13WI/p5Zdf5sKFC9SvXx+ABx98kG3btvHiiy9atwkNDeW9995DJpPRuHFjjh8/znvvvcfEiRPt+rlt2zaOHz9OUlISLi4uALz77rusXbuWn376iccee6zMc+MMCM+VQCAQODmW4ZObPfC7vHTo0MGubNu2bfTp04c6derg7u7OmDFjSE1NJTc312qj1WqtwgogODjYOuyVmZlJYmKijdhQKBS0b9/e+v+pU6coKCigT58+6HQ66+frr7/mwoUL1+x3q1ataNiwIT/99BNfffUVo0ePRqVS2dhYvutrJbpUKBQsW7aMuLg4FixYQEhICG+99RbNmze3GeosztChQ8nPz6d+/fpMnDiRNWvW2AS/Hz16lHvuuYewsDDc3d3p3r07UCTKSh6HhcDAQLRarVVYWcqKDycCdOrUyeaYOnfuzLlz5xxe04cPHyYnJwdfX1+b8xwVFVWu8+wMCM+VQCAQODmWB5DwXBXh5uZm8/+lS5cYMGAAkyZNYs6cOfj4+LB7924eeeQRDAaD1a6kkJHJZHZxPyVFTfF6y/n//fffqVOnjo2dxcNyLSZMmMBHH33EqVOn+Ouvv+zqGzVqBMDp06dp06bNNdurU6cOo0ePZvTo0bz55ps0atSITz/9lNmzZ9vZhoaGcubMGTZv3syWLVt48skneeedd9ixYweFhYXcfffd3H333XzzzTf4+/sTExND37597SYNFD+PMpnM4Xm9kWvVbDYTHBzM9u3b7eosw6LOjhBXAoFA4ORYHlTCc+WYQ4cOYTQaWbhwoTVO6YcffqhQG56engQGBvLXX39x1113AUXn++jRo1aR06xZM1xcXIiJibnmEGBpjBw5kunTp9O6dWuaNWtmV9+mTRuaNWvGwoULGT58uF3cVUZGRqkCw9vbm+DgYBtvXUk0Gg1DhgxhyJAhPPXUUzRp0oTjx48jSRIpKSm8/fbbhIaGAtikfbhR9u/fb/d/aQsnt2vXjoSEBJRKJeHh4ZXWh+pEiCuBQCBwciyiSogrx0RGRmI0Glm8eDGDBw9mz549fPrppxVu55lnnmHevHk0aNCAJk2asHjxYtLT063eLHd3d6ZPn85zzz2H2WzmzjvvJCsri71796LT6Rg7duw19+Ht7U18fLydt8eCTCZj2bJl9O7dm65du/LKK6/QpEkTcnJyWLduHZs2bWLHjh0sXbqUY8eOcd999xEZGUlBQQFff/01J0+etAsmt7B8+XJMJhMdO3ZEq9WycuVKNBoNYWFhmM1m1Go1ixcvZtKkSZw4cYI5c+ZU+ByWRmxsLFOnTuXxxx/nyJEjLF68mIULFzq07d27N507d+bee+9l/vz5NG7cmCtXrrB+/Xruvfdeh8PCzoYQVwKBQODkWDxXVT0sqFAoHA6VVSUymcyh96IitGnThkWLFjF//nxefvllunbtyrx58xgzZkyF2nnxxRdJSEhgzJgxKBQKHnvsMfr27WvTvzlz5hAQEMC8efO4ePEiXl5etGvXjldeeaXc+7nW0Nbtt9/OoUOHeOutt5g4cSIpKSkEBwfTpUsX3n//favN7t27mTRpEleuXEGn09G8eXPWrl1bqlfNy8uLt99+m6lTp2IymWjZsiXr1q3D19cXKBJfr7zyCh9++CHt2rXj3XffZciQIeU+rrIYM2YM+fn53H777SgUCp555plSA9NlMhnr16/n1VdfZcKECSQnJxMUFETXrl0JDAyslP5UNTKputPx3gA7d+7knXfe4fDhw8THx7NmzRqb/CPjxo1jxYoVNtt07NjRxh2p1+uZPn063333Hfn5+fTq1YuPP/6YunXrWm3S09OZPHkyv/76KwBDhgxh8eLF5R7rzcrKwtPTk8zMzFJnbQgEAkF5yczMJDY2FoVCQdOmTSulzYKCAqKiooiIiMDV1dVaLtYWvIrZbKZp06YMGzasUr04txrdu3enTZs2VmFY05R27UPlPb9rlecqNzeX1q1bM378eB544AGHNv369bPJI1LyRztlyhTWrVvH6tWr8fX1Zdq0aQwaNIjDhw9b305GjhxJXFwcGzZsAOCxxx5j9OjRrFu3roqOzDkwmUycO3eO8PBwuwtOIBDUHNXluQL7e+atxKVLl9i0aRPdunVDr9ezZMkSoqKiGDlyZE13TVDLqFXiqn///vTv379MGxcXF4KCghzWZWZm8uWXX7Jy5Up69+4NFGWkDQ0NZcuWLfTt25fTp0+zYcMG9u/fT8eOHQH4/PPP6dy5M2fOnKFx48aVe1BOhF6vx2g0kp+fL8SVQOBEWDxJkiQhSdI1p+kLrg+5XM7y5cuZPn06kiTRokULtmzZUmneQsGtQ60SV+Vh+/btBAQE4OXlRbdu3XjrrbesSwscPnwYg8HA3XffbbUPCQmhRYsW7N27l759+7Jv3z48PT2twgqK8nN4enqyd+9eh+JKr9ej1+ut/9fWLMqWKcvFpy4LBIKap/gwndlsvuEYJYFjQkNDbZanEVQOjlIq3OzcVElE+/fvz6pVq9i6dSsLFy7k4MGD9OzZ0yp8EhISUKvVeHt722wXGBhIQkKC1ab4Ok8WAgICrDYlmTdvHp6entaPZRprbcOSTE6IK4HAuSg+HChmDAoEzs9N5bkaPny49e8WLVrQoUMHwsLC+P3337n//vtL3a6km92Ry70sV/zLL7/M1KlTrf9nZWXVSoFlEVW1ZZV5geBWoaTnSiAQODc3leeqJMHBwYSFhVnXagoKCqKwsJD09HQbu6SkJOv0zqCgIBITE+3aSk5OLnUKqIuLCx4eHjaf2ogQVwKBc1JcUAlxJRA4Pze1uEpNTSU2Npbg4GAA2rdvj0qlYvPmzVab+Ph4Tpw4QZcuXYCi9Y4yMzNtliU4cOAAmZmZVpubFYu4MhqN1ZrnRiAQlE1xz5UYFhQInJ9aNSyYk5PD+fPnrf9HRUVx7NgxfHx88PHxYdasWTzwwAMEBwcTHR3NK6+8gp+fn3WFc09PTx555BGmTZuGr68vPj4+TJ8+nZYtW1pnDzZt2pR+/foxceJEli5dChSlYhg0aNBNPVMQroorSZIwmUwolbXq8hAIblrEsKBAULuoVU/PQ4cO0aNHD+v/ljinsWPH8sknn3D8+HG+/vprMjIyCA4OpkePHnz//fe4u7tbt3nvvfdQKpUMGzbMmkR0+fLlNrNvVq1axeTJk62zCocMGcKSJUuq6ShrBkmSbFZHNxgMQlwJBE6CEFcCQe2iVg0Ldu/e3Zrnpfhn+fLlaDQaNm7cSFJSEoWFhVy6dInly5fbBZa7urqyePFiUlNTycvLY926dXY2Pj4+fPPNN2RlZZGVlcU333xTa1bivl7MZrPNUKCYMSgQOA9itmDtZfny5U75/OjatSvffvttmTYymYy1a9dWqN1Zs2YRGBh4XduWxvbt25HJZGRkZJRpd9ttt/HLL79Uyj5vlFolrgRVR0kxJYLaBQLnQQS0Vy/h4eFOs1RLVfDbb7+RkJDAQw89VKntnj59mtmzZ7N06VLi4+OvmfT7eilNsL722mu89NJLTvEbEeJKANiLK+G5EgicA4uH3oIzPDgERR7Eqvouqvr+++GHHzJ+/Hjk8sqVABcuXADgnnvuISgoCBcXl0pt/1oMHDiQzMxMNm7cWK37dYQQVwIAm3grEOJKIHAWSg4DVtWwoCRJ5Obm1sinIrOTzWYz8+fPp0GDBri4uFCvXj3eeusta/3x48fp2bMnGo0GX19fHnvsMXJycqz148aN49577+Xdd98lODgYX19fnnrqKes9r3v37ly6dInnnnsOmUxmzW9o8Zb89ttvNGvWDBcXFy5dukR6ejpjxozB29sbrVZL//79rel/ykN0dDQymYwffviB7t274+rqyjfffMOsWbNo06aNje37779PeHh4uY/FESkpKWzZsoUhQ4bYlJ87d46uXbvi6upKs2bNbGbVW7h8+TLDhw/H29sbX19f7rnnHqKjo4Gi4cDBgwcDRcsIWc7bwYMH6dOnD35+fnh6etKtWzeOHDlid/zHjh2zlmVkZCCTyRxmdt++fTvjx48nMzPT+v3MmjULKFoEfMCAAXz33XelHn91IcSVABDDggKBs1LSO1JV3pK8vDx0Ol2NfPLy8srdz5dffpn58+fz2muvcerUKb799ltrDsK8vDz69euHt7c3Bw8e5Mcff2TLli08/fTTNm1s27aNCxcusG3bNlasWMHy5ctZvnw5AL/88gt169bljTfeID4+nvj4eJtzNG/ePL744gtOnjxJQEAA48aN49ChQ/z666/s27cPSZIYMGBAhV9QX3zxRSZPnszp06fp27dvubcr61gcsXv3brRarc16iWazmfvvvx+FQsH+/fv59NNPefHFF222y8vLo0ePHuh0Onbu3Mnu3bvR6XT069ePwsJCpk+fzrJlywBszlt2djZjx45l165d7N+/n4YNGzJgwACys7MrcHau0qVLF95//308PDys+5k+fbq1/vbbb2fXrl3X1XZlIqaDCQAxLCgQOCvV5bmqDWRnZ/PBBx+wZMkSxo4dC0BkZCR33nknUDTTOz8/n6+//ho3NzcAlixZwuDBg5k/f75VhHl7e7NkyRIUCgVNmjRh4MCB/Pnnn0ycOBEfHx8UCgXu7u4EBQXZ7N9gMPDxxx/TunVroMjb8+uvv7Jnzx5rHsRVq1YRGhrK2rVrGTp0aLmPbcqUKWWuJFIaZR2LI6KjowkMDLQZEtyyZQunT58mOjqaunXrAjB37lybmKnVq1cjl8v54osvrF6pZcuW4eXlxfbt27n77rutcVDFz1vPnj1t9r906VK8vb3ZsWMHgwYNqvDxqtVqPD09kclkdt8PQJ06dYiJicFsNlf6sGdFEOJKANiLKUs8QU1enAKBoPo8V1qt1mb4rDrRarXlsjt9+jR6vZ5evXqVWt+6dWursAK44447MJvNnDlzxiqumjdvbpN+Jzg4mOPHj19z/2q1mlatWtnsT6lU0rFjR2uZr68vjRs35vTp0+U6JgsdOnSokL2Fih5Lfn4+rq6uNmWnT5+mXr16VmEFRQm1i3P48GHOnz9vk9oIoKCgwBpr5YikpCRmzpzJ1q1bSUxMxGQykZeXR0xMTLmOr6JoNBrMZjN6vR6NRlMl+ygPQlwJAMeeKoPBUO0BiQKBwJbq8lzJZDIbUeKMXOthWdYasMXLVSqVXV15RKtGo7Fpp7RYsbL6URolz71cLrdr39F9uqLH4ufnZ7cEnKPjKNl/s9lM+/btWbVqlZ2tv79/qfsbN24cycnJvP/++4SFheHi4kLnzp2toSeWF/jKSgWUlpaGVqutUWEFIuZK8B+liSuBQFCziGHBqzRs2BCNRsOff/7psL5Zs2YcO3aM3Nxca9mePXuQy+U0atSo3PtRq9XlOs/NmjXDaDRy4MABa1lqaipnz561iWm6Hvz9/UlISLARHcWDvq+Xtm3bkpCQYCOwmjVrRkxMDFeuXLGW7du3z2a7du3ace7cOQICAmjQoIHNx9PTs9T97dq1i8mTJzNgwACaN2+Oi4sLKSkpNscJ2MS2Xes4y/p+Tpw4Qbt27crcvjoQ4kqA2Wx2+KYjgtoFgpqnuoYFawOurq68+OKLvPDCC3z99ddcuHCB/fv38+WXXwIwatQoXF1dGTt2LCdOnGDbtm0888wzjB492jokWB7Cw8PZuXMnly9fthECJWnYsCH33HMPEydOZPfu3fz99988/PDD1KlTh3vuueeGjrV79+4kJyezYMECLly4wEcffcQff/xxQ21Ckbjy9/dnz5491rLevXvTuHFjxowZw99//82uXbt49dVXbbYbNWoUfn5+3HPPPezatYuoqCh27NjBs88+S1xcXKn7a9CgAStXruT06dMcOHCAUaNG2XiVNBoNnTp14u233+bUqVPs3LmTGTNmlHkM4eHh5OTk8Oeff5KSkmIzIWLXrl3W1VVqEiGuBHZpGCwIz5VAUPOUfEO/lcUVFCWKnDZtGjNnzqRp06YMHz6cpKQkoCh2a+PGjaSlpXHbbbfx4IMP0qtXrwovX/bGG28QHR1NZGRkmUNeUBTU3b59ewYNGkTnzp2RJIn169fbDddVlKZNm/Lxxx/z0Ucf0bp1a/766y+bWXHXi0KhYMKECTbDe3K5nDVr1qDX67n99tt59NFHbdJbQNG53blzJ/Xq1eP++++nadOmTJgwgfz8fDw8PErd31dffUV6ejpt27Zl9OjRTJ48mYCAADsbg8FAhw4dePbZZ3nzzTfLPIYuXbowadIkhg8fjr+/PwsWLACKUkXs3buX8ePHV/S0VDoyqSIJRgTlIisrC09PTzIzM8u86JyF3NxcoqKi7Mq9vLxsAhwFAkH1k5CQYOc9adas2Q1PNikoKCAqKoqIiAi7AGfBzU1iYiLNmzfn8OHDhIWF1XR3Ko3nn3+ezMxMPvvsszLtyrr2K+v5LTxXglI9V2JYUCCoeRzFltzq3ivBjREYGMiXX35ZZTP2aoqAgADmzJlT090AxGxBAaUP/4lhQYGg5nEkpIS4EtwoNxoT5ow8//zzNd0FK8JzJShTXIlRY4GgZnHkubqVZwwKBLUBIa4EpQ4LXqtOIBBUPWJYUCCofQhxJSgztkoMDQoENYsQVwJB7UOIK0GZAkqIK4GgZnEkpMSwoEDg3AhxdYsjSVKZQ39CXAkENYsIaBcIah9CXN3iXOsNWKRjEAhqDkmShLgSCGohQlzd4lzLMyU8VwJBzVGaiBLDggKBcyPE1S3OtWYDCs+VQFBzlCauhOeqeujevTtTpkyx/h8eHs77779fY/0RFLF9+3ZkMhkZGRk13ZVSEeLqFkd4rgQC56U0D5UQVzXDwYMHeeyxx6p0H9HR0chkMpRKJZcvX7api4+PR6lUIpPJiI6Otqn7+eef6d69O56enuh0Olq1asUbb7xBWloaUHQtzZs3jyZNmqDRaPDx8aFTp04sW7asSo/nVkWIq1uca4kns9kshiAEghpCDAs6F/7+/mi12mrZV0hICF9//bVN2YoVK6hTp46d7auvvsrw4cO57bbb+OOPPzhx4gQLFy7k77//ZuXKlQDMmjWL999/nzlz5nDq1Cm2bdvGxIkTSU9Pr5bjudUQ4uoWpzxJQoX3SiCoGWrEc1WYW/rHUFAB2/zy2VaQ7t2788wzzzBlyhS8vb0JDAzks88+Izc3l/Hjx+Pu7k5kZCR//PGHzXanTp1iwIAB6HQ6AgMDGT16tM2C2Lm5uYwZMwadTkdwcDALFy6023fJYcFFixbRsmVL3NzcCA0N5cknnyQnJ8dav3z5cry8vNi4cSNNmzZFp9PRr18/4uPjr3mcY8eOtfMqLV++nLFjx9qU/fXXX8ydO5eFCxfyzjvv0KVLF8LDw+nTpw8///yz1X7dunU8+eSTDB06lIiICFq3bs0jjzzC1KlTS+3DpUuXGDx4MN7e3ri5udG8eXPWr18PFF2bjzzyCBEREWg0Gho3bswHH3xgs/24ceO49957mTt3LoGBgXh5eTF79myMRiPPP/88Pj4+1K1bl6+++sq6jcVzt3r1arp06YKrqyvNmzdn+/btZZ6vvXv30rVrVzQaDaGhoUyePJnc3IpfX5WFEFe3OOURTkJcCQQ1Q414ruaGlP75YbSt7TsNSrf95kFb2/dbOra7DlasWIGfnx9//fUXzzzzDE888QRDhw6lS5cuHDlyhL59+zJ69Gjy8vKAouG0bt260aZNGw4dOsSGDRtITExk2LBh1jaff/55tm3bxpo1a9i0aRPbt2/n8OHDZfZDLpfz4YcfcuLECVasWMHWrVt54YUXbGzy8vJ49913WblyJTt37iQmJobp06df8xiHDBlCeno6u3fvBmD37t2kpaUxePBgG7tVq1ah0+l48sknHbbj5eUFQFBQEFu3biU5Ofma+7bw1FNPodfr2blzJ8ePH2f+/PnodDqg6NqsW7cuP/zwA6dOnWLmzJm88sor/PDDDzZtbN26lStXrrBz504WLVrErFmzGDRoEN7e3hw4cIBJkyYxadIkYmNjbbZ7/vnnmTZtGkePHqVLly4MGTKE1NRUh/08fvw4ffv25f777+eff/7h+++/Z/fu3Tz99NPlPtbKRoirW5zyBKwLcSUQ1AyliahbfViwdevWzJgxg4YNG/Lyyy+j0Wjw8/Nj4sSJNGzYkJkzZ5Kamso///wDwCeffEK7du2YO3cuTZo0oW3btnz11Vds27aNs2fPkpOTw5dffsm7775Lnz59aNmyJStWrLjmeZ4yZQo9evQgIiKCnj17MmfOHDtxYTAY+PTTT+nQoQPt2rXj6aef5s8//7zmMapUKh5++GGrV+err77i4YcfRqVS2didO3eO+vXr25WXZNGiRSQnJxMUFESrVq2YNGmSnXevJDExMdxxxx20bNmS+vXrM2jQILp27Wrt3+zZs7ntttuIiIhg1KhRjBs3zu74fXx8+PDDD2ncuDETJkygcePG5OXl8corr1i/P7VazZ49e2y2e/rpp3nggQdo2rQpn3zyCZ6ennz55ZcO+/nOO+8wcuRIpkyZQsOGDenSpQsffvghX3/9NQUFBQ63qWqUNbJXgdNQnmFBMWNQIKgZamRY8JUrpdfJFLb/P3++DNsS7+5Tjl9/n0rQqlUr698KhQJfX19atmxpLQsMDAQgKSkJgMOHD7Nt2zar16U4Fy5cID8/n8LCQjp37mwt9/HxoXHjxmX2Y9u2bcydO5dTp06RlZWF0WikoKCA3Nxc3NzcANBqtURGRlq3CQ4OtvbrWjzyyCN07tyZuXPn8uOPP7Jv3z67e7YkSchksmu21axZM06cOMHhw4fZvXs3O3fuZPDgwYwbN44vvvjC4TaTJ0/miSeeYNOmTfTu3ZsHHnjA5tx/+umnfPHFF1y6dMl6Dtu0aWPTRvPmzZHLr14LgYGBtGjRwvq/5fsreU6KfxdKpZIOHTpw+vRph/08fPgw58+fZ9WqVTbnxWw2ExUVRdOmTa95fiob4bm6hTGbzeW6SQvPlUBQM9RIKga1W+kflWsFbDXls70OSnppZDKZTZlFbFjOk9lsZvDgwRw7dszmc+7cObp27YokSRXuw6VLlxgwYAAtWrTg559/5vDhw3z00UeA7T3TUV/Lu78WLVrQpEkTRowYQdOmTW1EiYVGjRpx4cKFct2n5XI5t912G8899xxr1qxh+fLlfPnll0RFRTm0f/TRR7l48SKjR4/m+PHjdOjQgcWLFwPwww8/8NxzzzFhwgQ2bdrEsWPHGD9+vN3L+LW+K0tZea7p0kSk2Wzm8ccft/lu//77b86dO2cjbKsTIa5uYcormoTnSiCoGcryXF2PILhVadeuHSdPniQ8PJwGDRrYfNzc3GjQoAEqlYr9+/dbt0lPT+fs2bOltnno0CGMRiMLFy6kU6dONGrUiCtXyvD6XScTJkxg+/btTJgwwWH9yJEjycnJ4eOPP3ZYX1YuqGbNmgGUGfgdGhrKpEmT+OWXX5g2bRqff/45ALt27aJLly48+eSTtG3blgYNGnDhwoVyHtW1Kf5dGI1GDh8+TJMmTRzaWr7fkt9tgwYNUKvVldaniiDE1S1MeYYEQXiuBIKaoqy3eSGuys9TTz1FWloaI0aM4K+//uLixYts2rSJCRMmYDKZ0Ol0PPLIIzz//PP8+eefnDhxgnHjxtkMZ5UkMjISo9HI4sWLuXjxIitXruTTTz+t9L5PnDiR5ORkHn30UYf1HTt25IUXXmDatGm88MIL7Nu3j0uXLvHnn38ydOhQVqxYAcCDDz7Ie++9x4EDB7h06RLbt2/nqaeeolGjRqWKlilTprBx40aioqI4cuQIW7dutQ6xNWjQgEOHDrFx40bOnj3La6+9xsGDByvtuD/66CPWrFnDv//+y1NPPUV6enqpAvPFF19k3759PPXUU1aP5K+//sozzzxTaf2pKEJc3cKUVzQZjUZxIxcIagCL5+rKlSusW7fO5oVIJBItPyEhIezZsweTyUTfvn1p0aIFzz77LJ6enlYB9c4779C1a1eGDBlC7969ufPOO2nfvn2pbbZp04ZFixYxf/58WrRowapVq5g3b16l912pVOLn54dSWXqI9Pz58/n22285cOAAffv2pXnz5kydOpVWrVpZUzH07duXdevWMXjwYBo1asTYsWNp0qQJmzZtKrVtk8nEU089RdOmTenXrx+NGze2esgmTZrE/fffz/Dhw+nYsSOpqamlzli8Ht5++23mz59P69at2bVrF//73//w8/NzaNuqVSt27NjBuXPnuOuuu2jbti2vvfYawcHBldafiiKTxFOz0snKysLT05PMzEw8PDxqujulkpycTGJiYrlsGzVqVGPuVYHgVuXixYvk5eXx7LPPsnXrVpYsWUK3bt0AaNiwIS4uLtfddkFBAVFRUURERODq6nrtDQSCaiA6OpqIiAiOHj1qFxxfWZR17VfW81t4rm5hyjssCGJoUCCoCSyeK0vSyYSEBGud8FwJBM6LEFe3MI4EU2mOTCGuBILqxyKg8rIzCfeSkZWVZa271XNdCQTOjBBXtzAlBdPkyZMZPny4w9mBQlwJBNWPRUB92j2bqGfdCS28mldKeK4ENyPh4eFIklRlQ4LVRa0SV5akZyEhIchkMtauXWtTL0kSs2bNIiQkBI1GQ/fu3Tl58qSNjV6v55lnnsHPzw83NzeGDBlCXFycjU16ejqjR4/G09MTT09PRo8eXeZ01tpKccGUk5ND9pkd1NGf5dy5c2XaOiNiarrgZsRsNmMwGOgXWZTfp7vmX5s6gUDgnNQqcZWbm0vr1q1ZsmSJw/oFCxawaNEilixZwsGDBwkKCqJPnz5kZ2dbbaZMmcKaNWtYvXo1u3fvJicnh0GDBtm42EeOHMmxY8fYsGEDGzZs4NixY4wePdrRLmstkiTZxFzFXIrm4EQdm0e7kXLhqJ29s+e6unjxYqnrTgkEtRGLeMrOzqbAWPTiEJ939ZYthgUFAuelVi1/079/f/r37++wTpIk3n//fV599VXuv/9+oGhxz8DAQL799lsef/xxMjMz+fLLL1m5ciW9e/cG4JtvviE0NJQtW7bQt29fTp8+zYYNG9i/fz8dO3YE4PPPP6dz586cOXPmmssh1BZKBrOnX7rq4UuMi7azd2ZxJUkSer3eqfsoEFQUi7jKyspiaqorqW296HrZRESJeoFA4HzUKs9VWURFRZGQkMDdd99tLXNxcaFbt27s3bsXKFp/yGAw2NiEhITQokULq82+ffvw9PS0CiuATp064enpabUpiV6vJysry+bj7JQUV4bEMwCcSTGx75y9B8hgMDjtsJtlSLAisx8FAmfH4pnKzMxkV6dATrm4sLf+1Vu2EFcCgfNy04gryxRly4KdFgIDA611CQkJqNVqvL29y7QJCAiwaz8gIMBmGnRx5s2bZ43P8vT0JDQ09IaPp6opGUMlzyhaW+pcmtnhOlOWRTCdEYuoEuJKcDNh+b3lZKQw/sBl5ian0CdazBYUCGoDN424slByYcfyrBhe0saRfVntvPzyy2RmZlo/sbGx19Hz6qWkuHIvLFqR/HyamYyESw6FirMOu1keMkJcCW4mLNe1lBHH1AATg3PyKEwssNY768uOQCC4icRVUFAQgJ13KSkpyerNCgoKorCwkPT09DJtHGUtT05OtvOKWXBxccHDw8Pm4+yUFCKSNpceoXU4c09dTj3h6lAgOuuMQcuxiDd5wc2E5Xo25xYN00dnmHliXY51eF6IK8HNgqPZ/7Wdm0ZcRUREEBQUxObNm61lhYWF7Nixgy5dugDQvn17VCqVjU18fDwnTpyw2nTu3JnMzEz++usvq82BAwfIzMy02twMFBdKubm5GLxkpCgVJCkU6HQK4i+cLHMbZ6K4uHLWuDCBoKJYxJNBn8LUAD+m1w9EXU9Nbm4uIF4magvh4eHIZDJWr15tV9e8eXNkMhnLly+3KT969ChDhw4lMDAQV1dXGjVqxMSJEzl79qzV5ueff6Zjx454enri7u5O8+bNmTZtWlUfjqCc1CpxlZOTw7Fjxzh27BhQFMR+7NgxYmJikMlkTJkyhblz57JmzRrrquZarZaRI0cC4OnpySOPPMK0adP4888/OXr0KA8//DAtW7a0zh60LFA5ceJE9u/fz/79+5k4cSKDBg26aWYKgq1QiomJ4bH3U+FADmdd1Mzx8yE/9u8yt3EmxGK2gpsRi3gqMKaz2U3LGU8NgfcFWlPLCHFVewgNDWXZsmU2Zfv37ychIQE3Nzeb8t9++41OnTqh1+tZtWoVp0+fZuXKlXh6evLaa68BsGXLFh566CEefPBB/vrrLw4fPsxbb73ltKEbtyK1SlwdOnSItm3b0rZtWwCmTp1K27ZtmTlzJgAvvPACU6ZM4cknn6RDhw5cvnyZTZs24e7ubm3jvffe495772XYsGHccccdaLVa1q1bh0KhsNqsWrWKli1bcvfdd3P33XfTqlUrVq5cWb0HW8WUFFfmQgl5YtFwZpRKiSL9fJnbOBPFxZWIuxLcLFheFFwKcmih1wNwbx3Iysy0qa9s8gx55BnybLzABpOBPEMehaZCh7Zm6WpfDOYiW71JXy7bitK9e3eeeeYZpkyZgre3N4GBgXz22Wfk5uYyfvx43N3diYyM5I8//rDZ7tSpUwwYMACdTkdgYCCjR48mJSXFWr9hwwbuvPNOvLy88PX1ZdCgQVy4cMFaHx0djUwm45dffqFHjx5otVpat27Nvn37rtnnUaNGsWPHDptwi6+++opRo0ahVF7NiJSXl8f48eMZMGAAv/76K7179yYiIoKOHTvy7rvvsnTpUqBIgN155508//zzNG7cmEaNGnHvvfeyePHiUvtQWFjI008/TXBwMK6uroSHhzNv3jxr/aJFi2jZsiVubm6Ehoby5JNPkpOTY61fvnw5Xl5e/PbbbzRu3BitVsuDDz5Ibm4uK1asIDw8HG9vb5555hkb4R8eHs6cOXMYOXIkOp2OkJCQMvsJcPnyZYYPH463tze+vr7cc889REdHX/M8OxO1Slx1794dSZLsPhaXqkwmY9asWcTHx1NQUMCOHTto0aKFTRuurq4sXryY1NRU8vLyWLdund3sPh8fH7755htrWoVvvvkGLy+vajrK6qGkuAKoRz3eSvRj5ZVE3PXxdtvo9Xq7MmeguKASb/OCmwXLtexZkMt3VxI5HhXD+9np5GUm29RXNh2/7UjHbzuSrr8am7rs5DI6ftuRuQfm2th2/6E7Hb/tSHzu1fvF6n9X0/HbjszcM9PGtt/P/ej4bUcuZly0lv3v/P+uq48rVqzAz8+Pv/76i2eeeYYnnniCoUOH0qVLF44cOULfvn0ZPXo0eXl5QFH4R7du3WjTpg2HDh1iw4YNJCYmMmzYMGububm5TJ06lYMHD/Lnn38il8u577777ETsq6++yvTp0zl27BiNGjVixIgR13ypCwwMpG/fvqxYsQIoElHff/89EyZMsLHbuHEjKSkpvPDCCw7bsTyHgoKCOHnyJCdOnCj3Ofvwww/59ddf+eGHHzhz5gzffPMN4eHh1nq5XM6HH37IiRMnWLFiBVu3brXrR15eHh9++CGrV69mw4YNbN++nfvvv5/169ezfv16Vq5cyWeffcZPP/1ks90777xDq1atOHLkCC+//DLPPfecTXhOyX306NEDnU7Hzp072b17Nzqdjn79+tUqz1ytSiIqqBxKxiYFZxxm+vRAXHTZBPi0QJV3hCBFlt0MSeG5EgiqD6vnypxvU27ISrKpvxVp3bo1M2bMAIpma7/99tv4+fkxceJEAGbOnMknn3zCP//8Q6dOnfjkk09o164dc+deFYdfffUVoaGhnD17lkaNGvHAAw/Y7OPLL78kICCAU6dO2bykT58+nYEDBwIwe/Zsmjdvzvnz52nSpEmZfZ4wYQLTpk3j1Vdf5aeffiIyMtJu/TzL0mPXauuZZ55h165dtGzZkrCwMDp16sTdd9/NqFGjcHFxcbhNTEwMDRs25M4770QmkxEWFmZTP2XKFOvfERERzJkzhyeeeIKPP/7YWm4wGPjkk0+IjIwE4MEHH2TlypUkJiai0+lo1qwZPXr0YNu2bQwfPty63R133MFLL70EQKNGjdizZw/vvfceffr0sevn6tWrkcvlfPHFF9bnz7Jly/Dy8mL79u02eSqdGSGubkFKChA/KZZVLfyBVO4Nag5x0MhbIio52Sbnl8lkwmw2I5c7l8NTeK4ENyOWa/l/lyQOxxXybjc1MsCYUzR70OK5v1aqmYpyYOQBADRKjbVsfPPxPNz0YZRy20fG9mHbAXBVulrLHmryEA80fACFXGFju+GBDXa29zS457r62KpVK+vfCoUCX19fWrZsaS2zzOxOSioSoocPH2bbtm3odDq7ti5cuECjRo24cOECr732Gvv37yclJcUqXmNiYmzEVfF9BwcHW/dzLUE0cOBAHn/8cXbu3MlXX31l57UCyj0hx83Njd9//50LFy6wbds29u/fz7Rp0/jggw/Yt28fWq3Wbptx48bRp08fGjduTL9+/Rg0aJCNUNm2bRtz587l1KlTZGVlYTQaKSgoIDc31xoXptVqrcIKis5zeHi4zXkNDAy0nncLnTt3tvv//fffd3hshw8f5vz58zbhPAAFBQU2w7TOjhBXtyAlPVAeqmwG5iiI0oQQq9HyncIbY042rS5etEuoajQaUavV1dndayI8V4KbEYu42l9HgUe/BrQC2hTouT062WpjNptt4kUrA63K/sGsUqhQKVTls5WrUMnLb3s9qFS228lkMpsyi+C0CCSz2czgwYOZP3++XVsWgTR48GBCQ0P5/PPPCQkJwWw206JFC7uhqLL2UxZKpZLRo0fz+uuvc+DAAdasWWNn06hRIwD+/fdfO0HiiMjISCIjI3n00Ud59dVXadSoEd9//z3jx4+3s23Xrh1RUVH88ccfbNmyhWHDhtG7d29++uknLl26xIABA5g0aRJz5szBx8eH3bt388gjj9g8L6513i1l5Tkfpb0UmM1m2rdvz6pVq+zq/P39r9musyDE1S1I8R9LXl4ezVwKGZacysl2z/GLPoZN9dxJjzWii4qiY6dONtsWFhY6lbgqnjleJpMJz5XgpsEyfG+UX31hOObqQmvj1VioqhBXNyPt2rXj559/Jjw83CaA3EJqaiqnT59m6dKl3HXXXQDs3r270vsxYcIE3n33XWuwdknuvvtu/Pz8WLBggUPxlZGRUWr8b3h4OFqt1pqqwxEeHh4MHz6c4cOH8+CDD9KvXz/S0tI4dOgQRqORhQsXWkcmfvjhh+s7SAfs37/f7v/SPH3t2rXj+++/JyAgoFbkjCwN5xrfEVQLxb07MZeiifQuugyUAY1oqmuK/xV/sv/O5uLFi3bbOlvcVfFjEesLCm4mTCYTeXl5hO1MRDHjNI9cKWRRYjIueVcfnrdy3FVFeOqpp0hLS2PEiBH89ddfXLx4kU2bNjFhwgRMJpN1Vtpnn33G+fPn2bp1K1OnTq30fjRt2pSUlBS7tAwW3Nzc+OKLL/j9998ZMmQIW7ZsITo6mkOHDvHCCy8wadIkAGbNmsULL7zA9u3biYqK4ujRo0yYMAGDweAwjgmKZsqvXr2af//9l7Nnz/Ljjz8SFBSEl5cXkZGRGI1GFi9ezMWLF1m5ciWffvpppR33nj17WLBgAWfPnuWjjz7ixx9/5Nlnn3VoO2rUKPz8/LjnnnvYtWsXUVFR7Nixg2effZa4uLhK61NVI8TVLUhxgZR+6SQqlQyDGQzaQJq4N6GHsQfyf7LIuXK2zG2dgZJiSniuBDcLZrOZzMxMfhup5dgjbgzKhfDYHApzrg5Tieu9fISEhLBnzx5MJhN9+/alRYsWPPvss3h6eiKXy5HL5axevZrDhw/TokULnnvuOd55550q6Yuvry8ajabU+nvuuYe9e/eiUqkYOXIkTZo0YcSIEWRmZvLmm28C0K1bNy5evMiYMWNo0qQJ/fv3JyEhgU2bNpWaj1Gn0zF//nw6dOjAbbfdRnR0NOvXr0cul9OmTRsWLVrE/PnzadGiBatWrbJJ03CjTJs2jcOHD9O2bVvmzJnDwoUL6du3r0NbrVbLzp07qVevHvfffz9NmzZlwoQJ5Ofn1ypPlkwSKa0rnaysLDw9PcnMzHTKi+HSpUvWRIQ7lr/BvobHuKxQ8kTzWTRzb0bejg+5Pfl71l2QE/HiLpttvb29qVOnTk102yHZ2dlcunTJ+r9Go7EJuBQIaisnT57k1MkTPHByInKZjHd5nOdnv0O3bt1YsmQJgF0wcUUoKCggKiqKiIgIXF1dr72BQHAdhIeHM2XKFJvZiDVNWdd+ZT2/RczVLUhx71NBahzRzZRkKhS4KYpmhLjVbU5Kqhx/bxM5OTk2N29nyzNS8s1dDAsKbgYsMwELMhL52NsLswxSAW1DLVlSltVODAsKBM6JGBa8BSkurr79R89fz55lcGpPQlxDAPhMOk6PsLocD/Mg+qJtpnZnE1diWFBwM2K5jg1ZSXznoeNzL08OeB6i/qv1yQvNs7MTCATOhfBc3WJIkmRzQ46NjcWQY6JVSGfrtGhfbSiyjP1kqBSYoo5BqzZWe6PRWCW5da6XkuLKbDY7Vf8EguvB4pEyZifxsDKby5KKVK9w5AVXaBOcY2cnEDgrtW3ZmspCiKtbjOJiJC8vj+Tkopw5xZcA6hfYn6HbvqCpSxZLUk7abG8RZ46mM9cEjoYBnal/AsH1YHkBknLTeEKWxYU8HZkBHWh3aSf7M8x2dgKBwLkQT6BbjOJDgrExl/j4BT/OK1zIlF3BE08AtAotBcpAIAuX7EsO23AW8eJIXBmNRqfpn0BwPVhztxVkgA4KZBrUHkUJFD3VEgUGAyqVqlI8V2JOk+BWozqueRFzdYtRXFylRZ/gfD13NjX25kSebWyV0atoxp2PKZmSOFPclaPUEOJtXlDbsVzDJzMUTNtRyCFjQ1QeRasleGtk1tm+NyKuLMlHnen3LBBUB5ZrvioT8IrX+1uM4p6ewoTTdAzWozcpqN+4oY3dzjq+vHXOG2NyBnP+e0u24Ey5rkrzXAkEtRmLaDqqyCd9XAP+KsghgGw+DPTH18fI7VlZ+Pj43NCLhFKpRKvVkpycjEqlcro1QwWCqsBsNpOcnIxWq63SEQ4hrm4xigsjZeYlhulyaKr3RKazXYrgX62BC/XcSVDkEhsbS/369R22UZOUDM63IDxXgtqO5RrOMRUFr2vkGnLlCnZqNYQXGmiRmQqE35DnSiaTERwcTFRUlE2uOIHgZkcul1OvXr0qnfgkxNUtRnFhpC1IAKBAG0LJfMF3+NzBvjX7yDmRw8WLF23ElbMMI5T2YBGeK0Ftx3JtB5/JIG57DPfNGE2IW31mJqUSaDZxyZAI3PiLhFqtpmHDhk7zmxYIqgO1Wl3lnlohrm4xiosrT2U2ehnIfO0zmnfw6kCztFBcjadJjT4J9HbYRk1SmogSnqvro7CwEKVSKYaHnADLNTytZTo9B7pxgDjc1F7USSykUF/AmdBMG7sbQS6XiwztAkElI+6itxgWYZSXl8fFMBduCwtlhXeKQ9sZzeM49JiO0KzDNuXO8pZbmrgSnquKYzabOX/+PGlpaTXdFQFXPVfuyqJrWfnfTMEJR1vTaEkusTkKGzuBQOBcCM/VLYQkSVbhERsTQ4JaiSST4e4W5NA+3aMux6QEXMyJNuVmsxmz2VzjHg4hriqP/Px8zGYz+fn5Nd0VAUUeqcLCQg7VcWOfl5owrYxIwCXEBW1DLenZ6YAQVwKBsyI8V7cQluzlADGxscx/NQ7lpzCg7giH9vOCMhgdEkSen8EuL4gzDA0KcVV55ObmAkULmgpqHpPJRFZWFn/5FS19k+hSdE3Hd42n/qv1STYWpUgR4kogcE6EuLqFKC6IYmJiAKjjG4aX2suhfZg2lCCjEV8PGYmJtt4rZxBXpcWbiJirimMRV4WFhSKppBNgMpnIysxgQH4eIzOzqasrSpUSYpQIzDfQSBENXF3gWSAQOBdCXN1COBJXYWFhpdo/3WAKm2OvMMxcwOXzJ2zqnCHuSgS0Vw6SJJGXl2f92xm+21sdk8lEfnoCQ3NyeTktnTDPZgDMvKJhS0I8Df5LIgrCeyUQOCNCXN1CFBcjnT2P8fS8eng1vFCqvUztQZK+KHlofswxmzpn8FyVJq4kSRIPnAqQn59v4/3Q6/U12BsBFAmmwswib3GuQYb036LqZrU7AGpzntVWvEwIBM6HEFe3EMUFkdwrj+3BHhz1SC9zm2TJBwBZ6rlS26opyuqDiLsqP5YhQQtCXNU8ZrOZ5Gw903YU8s2lgKsVrl4AuEgFNrYCgcC5ELMFbyEsgiMvL49msgImZmRSENypVHtJkngnNJhzeRKBcdncUazOGYaOyhJQ4m2+/OTk5Nj8L4LaaxaL5/VSbi5bxzVgkwk6S2bkMjn73A18o/MnoFCPZcEqIa4EAudDiKtbCIunJy42hgEaE/3SMznTaSil+X9kMhmXdDKyda5cyki1qXMGcVWWgBKeq/JRPN7KghBXNYtFLKXnF3mVFSYFclnRIEOKq4ydMg3d3K9e3+JFQiBwPsSw4C2ERRClXzqBq1KGwQwGTUCZ2wwNGcqlDy+R+E8iWVlZ1nKj0Vijs5QsubZKQzxwykfJeCsQMwZrGmsC0dQsFDNOc9fxZta69prGzEpOpVdqtvU7Ep4rgcD5EOLqFsLizSmM/5dLSiWxeg3Iy3ZedgvqSvt8Fx4Mk3HpwlmH7dUExcVTbGwsP/zwg00MlhBX5aOk1wrEjMGaxnLtdnY5z7FH3BjlftFa18S3Bd2SsvFNLbAmfBXiSiBwPsSw4C2C2Wy23rRNWRcZ1CIEmSTxuTEXN6VbmduuvdeEp1rLZ1GHoW0Ha7nBYEClUlVpv0ujuLBbsGAB27dvx9vbmz59+tjVC0qnZLyVBb1ej4uLSzX3RgBXxZLLfzMCTS6eV+sCWxH8XgFGo5HNo7LQarXiRUIgcEIqJK7OnDnDd999x65du4iOjiYvLw9/f3/atm1L3759eeCBB8QN2UkpLjZi8zNxNSlRorimsDIjsUflhcktH/Ol0zZ1NTljsPjxxMTEoJRDXFyctUw8cK6NJEl2MwUtiBmDNYfl2o3zNvGBtycukoI7/6szSkZ8GvqQlZ9FVlYWQUFBwnMlEDgh5RoWPHr0KH369KF169bs3LmT2267jSlTpjBnzhwefvhhJEni1VdfJSQkhPnz54sbsxNSXIws35jBoUdO8YjL5GtuZ5bMvBzhxisBfpgMsTZ1NTl0VPx4Hm2QTMaL7rhmnndYL3BMQUFBqbFVIqi95rCIpVgvGV94eXLK7eqLQoI+gYAXAwifGm6NgRTiSiBwPsrlubr33nt5/vnn+f777/Hx8SnVbt++fbz33nssXLiQV155pdI6KbhxLF6m/Px8kpKSAGgS1uSa2ynlSiKNbngZU9HKs2zqnMFzlZeXx+BuLnzmpqFfwd929YLSKc1rBUJc1SQWz1XT3HwCMsHTM9Ra56Zww81gxlNphoxooIPw0goETki5xNW5c+dQq9XXtOvcuTOdO3cWwbBOiEUIxcYWeZ88PDzw8vIq17YzvR6gzYk3OSEzUVhYaL0WnEFcJSUl8XKdIADSs3IZVqJeUDpliSvLjEGZTFaNPRLA1Zmw3XLzaJRWwNF67ax1Pmof1p5LJEhjYJkixWovEAici3INC5ZHWN2IvaDqMRqNyGQyMqKP8/rCeox/1Y/EgoRybetatzUAjXzlxERfnblUkyLa8raenBjP7fkFuJjN1M0osKsXOKaseCtLvXhJqhlMJhM5OTn4aor+d/EOsqnPNf+3FE5+mtVeIBA4F5WWiuHQoUPs3LmzspoTVDIGgwFJktDHn2aLlxt/BmopMJcvNs7oFkS+UYZaISPtwlGbNmsKy77TE+P4MiGJg5fiKDhzdeabyWQSuZrKoKCg4JoeDxE7WTOYzWYyMzN564CBhQdM4G4rrgpwLfojPwMQ4kogcEYqTVyNHj2aHj16VFZz18WsWbOQyWQ2n6CgqzcmSZKYNWsWISEhaDQaunfvzsmTJ23a0Ov1PPPMM/j5+eHm5saQIUNsZqHVVixeCHnGRaalZTA41UyQa9A1tioizZDB4IAw2noHcSIm2VpePL1DdWMZ9otLyUY2Owv57Cye/T3bmvvH0j+BYxzltyqJEFc1g8lkIisri/X3hLNsaDgXjLarI6wM0vJUoD8pyqIM7uI6Fwicj0oTV3/++ScXL168tmEV07x5c+Lj462f48ePW+sWLFjAokWLWLJkCQcPHiQoKIg+ffqQnZ1ttZkyZQpr1qxh9erV7N69m5ycHAYNGlTr3w4tnh5dYRL35eRyb24wLvLypc1wV7qT6GHG6KXm5JVLDtutborHXLkEuxAyPoSgh4JISUmxsxHYU1p+q+KIoPaaweK5UugUyBQytAqtTf2/bgp2ajXkKP7Lg1XL700Cwc1IpSURDQkJqaymbgilUmnjrbIgSRLvv/8+r776Kvfffz8AK1asIDAwkG+//ZbHH3+czMxMvvzyS1auXEnv3r0B+OabbwgNDWXLli307du3Wo+lspAkySo0fMksKvSpX+7tVXIVd+fdzUfzPsLkYXsjNxgMuLq6Vlpfy4MkSdYHymVzLOEvhaPyVFGYUkhKSgqhoUWzq8RDxzHXireyIMRVzWA0GinITEL14RmCmrfA7x0/m/reWTpG50STnK0DhOdKIHBGrstzdeHCBWbMmMGIESOs0/o3bNhgN8RWE5w7d46QkBAiIiJ46KGHrN60qKgoEhISuPvuu622Li4udOvWjb179wJw+PBhDAaDjU1ISAgtWrSw2jhCr9eTlZVl83EmLCKjoKAApZ9EjFKJOqTZNbaypU9IRwboTHTTXbK5mdeE56q4aGpXNw6VZ1GA78t5meQnXrDWCc+VY/R6fbkeyGKNwZrBZDLhmXWGY4+4saRFIgqZwqa+tTGQbknZqDOKhvqFuBIInI8Ki6sdO3bQsmVLDhw4wC+//GIdXvjnn394/fXXK72DFaFjx458/fXXbNy4kc8//5yEhAS6dOlCamoqCQlFM+MCAwNttgkMDLTWJSQkoFar8fb2LtXGEfPmzcPT09P6sXhOnAWLyIiNucRvET4MDA1hi0vyNbayJcxHzS/DtczvqSAhPt5aXhMzyoqLpiYZ2byWksYHicmMM+VjTL+a6FR4rhxTHq8ViBmDNYXZbIb8oniqPOyH7k/79cf/nRzePqi23UYgEDgNFRZXL730Em+++SabN2+2SbnQo0cP9u3bV6mdqyj9+/fngQceoGXLlvTu3Zvff/8dKBr+s1Ayb095cvlcy+bll18mMzPT+rHkknIWLN6lhEvnSM6TUJvNBHo0qlAbWTo/ftdo2eSnI/F8zc4YtIgms9lMM1Mew7Jz6JlXFMguZV8VwcJz5ZjyiisQQe01gdlsJp1UPvD2ZIu3/fJULh4uuIS4kKPMsdlGIBA4DxUWV8ePH+e+++6zK/f39yc1NdXBFjWHm5sbLVu25Ny5c9Y4rJIeqKSkJKs3KygoiMLCQtLT00u1cYSLiwseHh42H2fCIoDOxyXz7YvRBPxYj9aebSvURooxk5eC/HjP24v8uH+s5TXpuUpLSyNEVyR64yUNF1VKDIVJVjvhubKnvPFWFoS4qn5MJhPpqly+8PJkh499WOy/yn9pOLchLr2uerWEuBIInIsKiysvLy/iiw0LWTh69Ch16tSplE5VFnq9ntOnTxMcHExERARBQUFs3rzZWl9YWMiOHTvo0qULAO3bt0elUtnYxMfHc+LECatNbcQirmJiYgAIqxeGXFaxrz7YNZiGeRK98/KR0q+u4VeT4iopMYEMfxdilUqmBQdwT90Q4jyz7ewEV9Hr9Q5FZ0JCArt27bIrF0Ht1YtFJPnlFzAqM5s2+Vo7m2ClArdCE92CzdbftniREAiciwqLq5EjR/Liiy+SkJCATCbDbDazZ88epk+fzpgxY6qij+Vm+vTp7Nixg6ioKA4cOMCDDz5IVlYWY8eORSaTMWXKFObOncuaNWs4ceIE48aNQ6vVMnLkSAA8PT155JFHmDZtGn/++SdHjx7l4Ycftg4z1lYsIuNybFEahbCwsAq3oZareT6lLrNT0vApltndZDJV+43dcjzZidE8FRLIgNAQ8pRq3E1mlLKrnhbxwLGntPxW06ZN48knn+TgwYM25UJcVS8WcVU/J4+X0tLpqbefhd3H9zb2X77Me5np1phX4bkSCJyLCqdieOuttxg3bhx16tRBkiSaNWuGyWRi5MiRzJgxoyr6WG7i4uIYMWIEKSkp+Pv706lTJ/bv328VEy+88AL5+fk8+eSTpKen07FjRzZt2oS7u7u1jffeew+lUsmwYcPIz8+nV69eLF++HIVCUdpunR7L2+2QrpdpOqo+uB4DBle4HXlAE4jfR5DSdjakXq9Hq7V/w64qrIs2p17AR2uiUCZjqvk2usZ9y+YEmZ2d4CqO8lslJCQwxOtfvnvSjZVHdnLbbbdZ68Qag9WL5YXA7b+XBJnWx95IUzThxtMVsrMy8fb2FuJKIHAyKiyuVCoVq1atYs6cORw5cgSz2Uzbtm1p2LBhVfSvQqxevbrMeplMxqxZs5g1a1apNq6urixevJjFixdXcu9qjsLCQgoKCkj3VfCXhxY/9fUJRV1Ee4hfRpi3mZiMDOvCzzUlrjJSs3jsbAyeQWF43tWYc8dNxKSZ8DcaUSqVQlyVoLR4qz07tzGnR1GusibRe4FpNtsUFhbi4lK+hLOCG8MiklafNbM/Wk/70U3sbVRF+a3kMhn5GYkQFi68tAKBk3HdSUTr169P/frlT0QpqDmMRiNxsTGM1ufSIcWIul33Um3VanWpcVTHNWYeDqyDIaGAF6OiaNu2KCi+uoOeLaLp6BUDM9fk8/TTvXk0sgdNhuZjNpvZ+lw6/v7+4oFTgsLCQofnJOv4H+S1kfGvWk0OaXb1er1eiKtqwvL9bGzrgVurYAzueZScPpSLkRd8fclXyOicWTSBQ3iuBALnotKWv/nf//7H119/XVnNCSoJs9lcNLU7+jgtzEbuycgl0q9jqfZ+fn6l1ulcfDFqFZj8XIiKirKW15S4siSwDQgIIMOUQcSkCOo8Wofk5KIcXmazWSTBLIYjr1V+fj7hhWeY7efD2JBAViG3WUIIxIzB6sRsNlNQUIBMI0OmkOHl5mVno5Qp+cPDje1uWnJzEqzbCQQC56HSxNWLL77I+PHjK6s5QSVhESKFCf8CkFCoAVnpw4I6nQ6NRuOwro5rHRoeaMjZ58/arCNZ3UHPlmNKD06m3uR6pAelY5bMaG7X4NnRk+SUqwlShffqKo7E1V8HDjAgUk5zfSGqPDPnUyVOnTplYyOC2qsPk8lEZkY6nt/EkD/rPJ38b7ezUcvVjI/PZnZyKuRlWLcTCATOQ4XFVWmzjf7991/xA3dCLMHs+pyL7NW4ck7lXaqtQqFApVKh0+kc1qvkKnr6BTG1vZLwnMM2+6iuN+fi3qiu7fR4tPPARRWLt8qbe+LymZaQhiL56jJMIu6qiNLirf7eu5mzAVq65RQQuSGM5N+S7ZaxEuKq+jCbzeSlJXD0ETfOj1Wjlasc2vVOlrgrMRvzf9+p8FwJBM7FdeW56tKlC6+88gobN26sUEJCQfVjEVcZrqk8HhTAwrDSF1nWarXIZDLc3OyzQlto56fnnT6u3OV5xaa8uvJdWcRSQUEBAzOyeC0ljY6eLVDKlYzLLGCCMQ9Z5tW+CcFfhMFgsBOakiTx664DTA/yY1BYMKEtQ+kWpkB/6ZCNnVhjsPowmUwUZiYCkGsASaF2aPdOUlcC3s3hYLoXIMSVQOBsXNfagkOGDOHIkSMMHToUb29vOnXqxEsvvcQff/xRFX0U3ACWB+rF1AKCcgoJkZceU2WZ8VfWzL+0kHp85unBhXpqG49GdcXlWI4nOSmJHgojw7JzaBpUNHSSKy9KqSHPTbKzv9Vx9BL077//km5IRx+jJ1AdyFjfVLaPc6OH2zkbO7HGYPVhNpvJy4rnfW9PvvTwxCw5Fk2uPq64hLiQll80AUG8RAgEzkWFxVXnzp156aWX2LBhA+np6ezcuZMmTZqwcOFCBg0aVBV9FNwABoMBvV7P119fYcvTZxnT8LVSbS2xVnK5vFSBddlTy2IfL/YG6oiNuvoQrm5xlR4fjZu6KPeSURsAQIbaiwsqJYVcXb5IPHSKcCSudu7YTmFiIWF7wljQfAEH6gYwLCSIMy20Iqi9hjCZTOQUJPCllyfLAjyQ4Ti/2MWGF2k4tyEpXkXfk/BcCQTOxXWlYvj333/Zvn07O3bsYPv27RgMBgYPHky3bt0qu3+CG8RgMBAXF4ckSeh0Ory9S4+5Kh7IrtPpHMbXhXu2pO/pXNob9GRlHoamLYHqGxa0iKW8lAscdHVBm2/GLFcjA74Nhr3aEHrq87FcicJzVYSj5KGaixs4+7Qb0X5a1HI1BR6BnM5T4+ln4szJv/Hr1stqK8RV9WAymZDnZTIqM5tEg0upyVvryIzkFppo7ZZk3U4gEDgPFRZXQUFBGAwGevbsSffu3XnllVdo2bJlVfRNUAno9Xpioy/gpoJ69eqVerN2cXGxyUKv0+msqQ6KU0dbl0djjTRxy+GrrNPW8uoKerYmEM25yIQGgbiYJZb9V+el9MLDlIlabrDaV/dDx2AwcPHiRSIiIlCrHcfLVDeFhYV2IjMlJYVGbvFE+KpwqeNDFtDKrytvHPmcTsY8VqbshWLiSgS1Vw9msxmP3FweT0vnQE5wqXaP5obQNfkYf6QWeZiFuBIInIsKDwsGBQWRk5NDTEwMMTExxMXFOXwrFtQ8llgZWfwBen7UmA6PmzCaHXtySg4DajSaUoVYpioQAJesaGuZXq+vlqBni0gw5icRXmggSH91aZahbnewJ+Yyw+PTrH2pbs9VQUEBBoOB/Pz8at1vWTgaEty9cwfxnfzoXq8OvwX4A+Dn4k+zPC+CTSbUKWLGYE1gMplQGIqWlypUlD6xxLIsjpu8yGMshgUFAueiwuLq2LFjJCYm8uqrr2I0Gnnttdfw9/enY8eOvPTSS1XRR8F1YjAYkCSJTP1FotQqzrkpUcodOytLiquyZg0avSPJkclQK1KtZZIkVYuQsa4rGGdk4tYYno65+navDWrI2VQTUWkmsrOzbeyrC8vsTGcKAHckrpKPrue0zpVMhQIXz0bWcr1vMwACjPazQcWMwarHZDJxKEXF23v0XFJGlmqndPtPXCmKrm8hrgQC5+K6koh6eXkxZMgQXn31VV555RWGDRvGkSNHeOeddyq7f4IbwPKAr5OVwmfxiYxK9yzV1lEAe2n5rn4N9aFzeCgvGFQ2wxHVEZdjEUu/nTVwz+p8Tvj0s9aZA5rTYYWcYT/lWwOyq1tcWfbnTDFKJcVVYWEhdfNP8nV8Im9n+tDaq91V2/BW/E/nRn59pU1Qu5gxWD2YTCb+9DPwzYgGrAkpfagv1g1e9vfltzAPJEkSqxEIBE5GhcXVmjVrePbZZ2ndujUBAQE88cQT5Obm8t577/HPP/9URR8F14nlAR9szqRzgZ4Ors0d2snlcofxQaV5rkIDi7wbJjcZ8fHxdvurSiyeIUs8WGBgoLUuz5RHyIQQ6k2pR1JyzQT6WpO2Oom4MhgM1j5ZOHjwIP0iigIuW0YOwVVxNffZUTc1M/x9+UCts8vU7izHdDNjNpspkBUgU8jQqm1feFxdr35P+VoXftO5cdxLYx2CFuJKIHAeKhzQ/vjjj9O1a1cmTpxI9+7dadGiRVX0S1AJ6PV69Ho9odpCQIFrHcfiqrT4KldXV+Ryud2QQyefTnz47IfEHo/lYtOL1K1b17q/qsZkMiFJEsoeEvV86pHtlW2tU8vUqNqqUKHicsJlq311Yl1uyEm8PI6GBE/u+YPH6yswSZAb3Nmmrr5XK1z+cSH2eBInU07StWtXa50QV1WLJElIkoTPznTifk2h25tP2NS7urpaY9/CvRoz7Ww6gQYjWZmZaLVazGYzcnmlrWgmEAhugAqLK0czyATOiV6v53JcLIpQHZmYcQmsj6NVBUvLaWWJu7LEL1lwVbgyroU7PvVcMV3aBxQ9gKs66FmSJEwmExkZGXS4w40zGhfclFf7ppQruSfWQCSZ5OWeAB6wDplU10PHIqpMJlNRcLKi9HUcq4OS4kqSJA6cOEjvNgH0VnoyUOVuk0mprqYuvZN7M3/NfE51F2sMVieWl5hlPXJo4K1hj9L2u1OpVNaXHT9dOHdkZJNRYGZvZioEB2MymVAqryu7jkAgqGTEa85NjF6vJzXqb94K8GVicCDxSsez/8rKyF5a3FWfUAOTOqjxyLj6AK5qz4bFC5WaEMv0jAxeS0mjvk8rG5uhWWbGG/PQZF9dvLk6466K78sZvFclZ/KeP3+ec+75JPq6sjcwxKHHsn2jEB5pq6K58bhNuRBXVYvJZMJoNOLlUjS85+IVZFOvVCqtYl1SuBK5whP/d3LIyBMzBgUCZ0OIq5sUs9mM0WgkNv4yfon5BOSbCXR1nDenePLQkpQWd3Ug0J8Zfj7EelydMWjx1lQVFuGSG3+OTgV6Bqbl4u0WamNToPICQFVg26/qwOJZs1DT4spRvNWOHTvIOpaFdreWwcGDHW7X2t/MZ0M0jGhTaBPULmYMVi1ms5nsrEx+DfRkmac7BR62LzYqleqqZ0omwyPYE5c6LqRnFa1IIHJdCQTOgxBXNykWL9LJ6EzWvRJF5JE7cJG72NnZ3LAdUDK5qIVLPu78z11Hoq/tG3NVeq+sOa7SYgBIKbQPws/R+HBepUKvyrbbrqopKWRqOkbJUbxV3NEtdPSEfsF96OzT2cFW8LfOlTvr1eWjFkGcPXnMWi5mDFYtJpOJvPRElnt7sMjHmxyl7e9OqVSiUqmuFkyEhm81JCmvKFRDeK5qB5IkUVBQQHZ2tnhZuYkRA/Q3KZYHe0xMkRCpV6+eQ7vSPFMWZDIZOp2OzMxMm/LbQ7pT/9RhWhkLiL9ymTp1Q637LWuY8Uaweq7yYjno40KmXkdQCZsN/mY2uAZzhyyXTv+VVdcbfUkRV9NCpGQi0/T0dPp6XmTiBDcu1blEdinbeenqk62QE42KjFN7oFtva51er8fFxV6kC24cs9lMQXo8Q3JySZQp8HC1XWRdqVTavAh5GCVMZjO6vLPW7QXOh9lspqCggNzcXHJzc8nLy7N+V2FhYbi7u9dwDwVVgRBXNykWcWVMjUajLPoRO6KsIUELjsRV0+AeNNj5Oq5KWHnmLxtxVVVYxMsVVRITggNp6AlvlLDxcQ3AwxSHRnZVUFWXuHI2z1VJcbd71y6CbvfkT7VEnbA7St0uyDWY+THQxxTHx7brN9f4Md3MmEwmDFmJTE/LID5XQarSw6a+pLhafDaPdu6prMyqZ91eUPOYTCby8/OtYio/P79UD1VSUhI6na7U1TAEtZcKi6uCggIWL17Mtm3bSEpKsntbOnLkSKV1TnD9FBYWUlhYyG2TXKnr3giD699AWzu78niZHHq3ZAri9DoaKHMojD0KPABU7cPX8vBwMeUSXqjAz+RhZ9PfrwcvH1xHTKaZpIICXF1dq21YsOR+alqIlBRXcYd+549B3qQrFLym1dGslO1kMhl13Juhyogh0GSbqV0EtVcdJpMJU3aRms022d6aZTIZcrncRlwZ5FogFXlh0XI5N4PnSpIkEhMT8fPzq3UzH9PS0khLS6vQb8QiwkqbOCSovVT46p0wYQKbN2/mwQcf5PbbbxeK20kpKCggLjaGeJ2a82o1Gm/7YUGZTGaTmLA01Go1SqXSTjwkqgMxqPVk5ly02W9VYdm/6YSeiZdSUN82zs7GxT+Cc2lmotPNmFNSqFO3bo15rsxmc42lYygZH2UwGPAtOM7AHG/2ab1p5Fl2fjpNZBc4vIHm3gZSUlLw8ysaohLiquowm83E5cqY95cev7r1KB4RZxEaNuJKWfTSozTmWLev7ej1elJSUnB1dcXLy6umu1MhkpKSrutFLjk5WYirm5AKi6vff/+d9evXc8cdpQ8rCGoWy4M1PfoflmQnc06hwrVVezu7shZnLom7uzvp6ek2Ze9HhPCvyoDh30Lu/q/Msp5hVYhuy41r8b5c0tLy+enBXnY2Jm0AfX7x5PLly6zsWySuaspzBUXeo/IMvVY2lmSrFo4cOcLAEDMd0zKIDX+cTFnZP/1U3zCWeHmS7iMn8OQx/P6Lu7LMGBQvVZWPyWTiEFkcH9UAbbrGRlxZAtmLi6v9Pkp+1/riVlBAc26OYUGLeK/uZatulJIzhSuCJQ6rqmJVBTVDhWcL1qlTRwTgOTkWgaO/cpo6RhMR6TJ0Kvt1BSvyY3Y0NFjfpznGHCMZWRk2XpuqCuQ2GAwUFhaSlpYGQEBAgJ2NJEl4j/AmbFoYl1OLsrTX1GxBqLmhwZLfwdHdG+lYt8iDlhvc5drbu3qz1NuT73U6jpz+11ouZgxWHWazmSxDFjK5DJVCZVPnSFxd0sr5TedGks5s3b62Y40VrWXi6kbXdhTJuW8+KiyuFi5cyIsvvsilS5eqoj+CSsDy8JOlFw3XZci9HdrdqLh6qMFDXH75Mon/S+TixatDg1UlKIxGI8lJiUROCyN8SjgGjb2YkclkyBrIcG/pzuXM6hVXjkRHTQkRu/0m7SZKpSRREYJR4+d4o2L4qHwISwsjflU8/57516aupmPJblZMJhN+UQZyZ56hQ7ztsK2jYcGW5iCmpabTOq1oVujNIK5qq+fqRr2GOTk5drN7BbWbCg8LdujQgYKCAurXr49Wq7XNuwJWr4Kg5rA8/NJdkvjJ3Q25JpBGDuwqMlylUqlQq9U2D22VXMXCgT5Eqk1End0HjRvb7L+yMZlMZF85ja6FDpNMhrKUoa0HEiXC5SnkZp6yblcdGI1G69urZdjMGTxXUVFR/ICBHXVD6OnSlInl2F4mkzHMdxi/b/2d0wGnbeqEuKoazGYzI/3OsmK8hs0y24kEFlEll8uRyWRIkkRTl3A6J29kZ0ZRnRgWrDkqo7/Jycmlpsy5VSh5/6zNVFhcjRgxgsuXLzN37lwCAwNvipNws6HX65EkiUtBZlb6+dLX5GYnruwSEpYDnU5nJ57vDIWmWiVfxP9ts//KxuJ2L0yO4kOSOW1S49XOy6Ft3zwVnVzzWJVb1FdL/FFVXqsmkwmz2cz48eORJIlly5Yhl8trTIgUH6LcuXMnCnclmCAsoFMZW9nSMiKAeb1c8NNmiaD2asBkMqGl6NxKrrbe5uIeK6VSicFgICukK6rH38XNzY39U2u/uDKbzdbr9lYUV1lZWRT8N8P5VuX8+fP4+Pjg6+tb0125YSosrvbu3cu+ffto3bp1VfRHUAno9XqSk5OJO5tHuEpJs+Yd7WyuJ3jSkbj6OdCfczoV9fJirEk7q+Lha7l5SZlX6KouwCtLhVzmeFTb4OoLXEBjzLCWmc3mKp21ZzQaSU1N5fDhwwDExcVRr169GhsWLC7qduzYQcLBBEZFjuKu9neVuw2NqyuPd9VwRqnkn2JB7UJcVQ0mk4kT/grOe7qjdHUhpFidI3Glddeh9FJiUBkwGo21fliw+DV7K4orKPJehYaGXtvwJkSSJPR6/U1zf6lwzFWTJk3E2LCTo9fruXDhAr9+ncKJT8zcHna/nc31iCtH2yR5eHLE1ZVMj6s3RovnrDKx3LwUOYkA5Mrtc1xZyNf5cU6lIk9z9Uda1Tdrg6EoZUGrQDkPt1IRe/Yf4Ooaj9WNRdRlZWXRT3ucpYNcua9tfTSK8g8Fp6tc6BpWl8dCAkk9v9Om7dq6bIckSWRkZDilEDGZTOzz17DIx5srWtvzW1xcWTzOyYpkmrzfhPDnw8nJyan1nquS4qo2XWOV9RvPzMy8ZYfdLV7Lm2XCTIXF1dtvv820adPYvn07qampZGVl2XwENYvlYX7hwgUAIiMjHdpdj7hSKpV2S5909+vK3KQURmZlkp1dtKCKJEmVLigs7WXLUzjo6kKixnGQPsBBHzP31w1mS8RVIVHVDx6j0UhSShLvjXTns/u1mGMPWeuq+2ZRXNDt2b2bh1speay9mrruFXtYuSvd8TdAmMGIMe+Mtbw2zxhMSUkhLi7O4bqLNY3JZKJzXj6Ds3Opq4uwqSs+hG8RWl4qDXKzRIhORm5mmlMKxopQ0mNRm46nMu8vxRdLv5Ww3LMczbqujVRYXPXr1499+/bRq1cvAgIC8Pb2xtvbGy8vL7y9S3/gCaoHy1tPVtzfNAuQ0zAywqHd9Y7rl0zD0SSsN4Nz8+ikNXPpzHG7flQWlh/eCX8jE4ID2RxoO8RXPDjfzz0UT5MJncxsvelVh+cqOi2aZ1uH0q1eHZTpZ6111S1Eit+czh7+g0fbhDI5wJ9k39JyspfO/NxmrLscT+Ms2wDr2vh2XVBQQGJikefT2cShJEnk5mTzWF42c1NSaebfzqa++JC25e9gTT2ORMeyLTGegowEJEmqVd6ekpS8pmrT0GBl9jU9Pd3prs/qwHLfsqQSqu1UOOZq27ZtVdEPQSVhuUFpws6ifbsJ2twTdjaurq7I5RXW1UBRSobib1ZmtQeJBSoCXQ1kX/wLOnSx9qMysw5bbl4+UiHhhUoC1P429VqtloKCAiRJ4s7gnjx+8nP0Rol9aWn4+ftXi+fKr+AormYzASYTPsZUa111CxGboGD1KdIVAZx01eLicu0UDCXxiLwTDm2ghY+BpGJB7bVNXEmSRFxcnPV/Z3t4SZJEbloCCnnRpAuVx9XrW6FQ2EzGsHiuZHIF2YUyvFwkCjOL8iRVdWxhVVLSc2U0GmvNIuGV7W1JSUkhJCTk2oY3EZZzKElSrb6OLVRYXHXr1q0q+iGoJCzxTnnuJgrkclzcAu1sbiQTsKNtjyt92KnIJCblrDWrdFV4riRJQrUjjUd9U/AZ+pxNvUqlQqVSFT003QM5nw5xmSbSk6/g5+9fLZ6r0LQsvndJYL2bG7H1ZEQajSiVymp/kFv29/fffzNSkcPUyyb+jbz/umZLSkGtAGjiJ2f3iaP4de8D1L6g9uTkZJs+O5u4MplMZGRmMm+3nkBPDbc/eNWzXHKNveL/5xgVeLkYMeYUifna+lAqPlPQwq3quYIi75W/v3+FZ3TXZkomoq6JlS0qk+taGbOgoIB//vnH4cLNQ4YMqZSOCa6PwsJCkhITmZOeRq4xm7iOU+xsbkRcKRQKNBqNzaSGRXUjiNVcQRGdxfD/yipbXJlMJrKysnh1S1GszMHptsv5qNVqax4uSeHCoI3BnDlzho87ZtGQqo+5MhgMuBRmcFKtZqm3J21cCoiMuURE/chq9/JYhMNfOzczqp4CZaEBedgDXM+7daGLN8/5+vOvi5IO/+6DWiiu8vPz7TJgO5u4MpvNXM7NZtWoBpAP30pm62zYkg/Y4v9/6e9JgRuEpF+2tlMbcfQbuZXFlSRJpKamEhQUVKntOjPFxZXBYLj1xNWGDRsYM2aMw6A7mUxW62es1HYKCgqIP3eUXhoZXoVGcgLaUnL0+kbXsNLpdDbiqqFHE878e578mHxrPqnKfvgaDAbrA9LDw8MuZsyS5NSC22A3wgaFEZURxV3cVS2eKzcph0aFhfTPyaW1Xk/KuUNWcVWd6/FZhIMiejvKUBkpMj8MujrX1ZZcJueAiy/ZLnlkJV22iufassag2Wy2GQ604GxBsyaTiZScFGReMlBik2akpOequGdqn4crlzUKHkpNt7ZTG3F0v6gtx2IZxqpsUlNT8fPzs/v+b1ZKLjRf26lw4M3TTz/N0KFDiY+Px2w223xqy4+hvHz88cdERETg6upK+/bt2bVrV013qUwss7j0MUcBuFzgiqRQ29jI5fIbdjWXXApnTOMxXJp7ifgt8VYBZDKZKvV6MBqNXE66QKM3IqnzVB3Mku3NTK1W2x5XKLi3dOdK7hVrf6oKy+zIv+rI+cbDnZFZ2YzKysFw+W9rfXX+NvR6PbGxsfxbR89MFw/Oh9nnOasIvVzuJvrdaC7svGAtqy0zBpOTkx16RZztfmUymVCn55M78wyBf9imGSlrWLBnqsS01HS8c4rEifBcVT9VdR1ZvFe3CiU9V7WdCourpKQkpk6dSmCgfSzPzcT333/PlClTePXVVzl69Ch33XUX/fv3JyYmpqa7ViqWWRZJhf+yyNuLLR7+djZubm437G3QarU2bbio1fwx1otLU3Rc/vewtbwyh8OMRiOmtP2o62nwqS+zebOXy+UoFAobcXVfhozpsSnclXPGun1VYbm5nvJz5QcPd/6XH0z/VXlsPptntanOoUGDwcDhw4eJaurFmhAv/okof+JQRwxuOpi8U3kkxibaeKydPag9Ly+P5OTkUuudSRyazWYa5R/j4ngNb9RLsKkr+TJUPMC9c6aGhzOy8MjRW9upjTjyXNUWcXU9/SzvQs+pqalV/hJQU7n4ilPyBfSWFFcPPvgg27dvr4KuOBeLFi3ikUce4dFHH6Vp06a8//77hIaG8sknn9R010rF8rBI0mWyzMuDfb72s/UqYxxbLpfbDi3KZDTxU1DPU07epav5nSrr4Wtxu/tkpPNRQhIPxdr+8CwPn+LDgncW6hhrzCMgLxOo2hu1wWAgNzeX4dnZPJ6eiZtXNzbFmjkWd3Vx8+p6kFuW4bkUc4nkX5PxuOJBG6/2196wDNxcVfw2xofzz+g4d+KotdyZxVVpw4HFcaYbuMlkQqEvyhOoV9h6hh0NC1mGBv+Q9UQ1J5tvo/2s7dRGLOJqwYIFPProoxgMBqf6fsqiPPcWs9nMmTNnWLFiBZMmTaJjx448/PDD1zxGs9lc5ev1JiQkcOnSpWsbViElz4MzvfhcLxUezF2yZAlDhw5l165dtGzZ0u6tavLkyZXWuZqisLCQw4cP89JLL9mU33333ezdu9fOXq/X2zxoaiqZqiW25+iBLMILCmnS3N5jcaPxVhbc3NxsEjG+FxTAUQ8THc+e4c5i/akMLDcv99xUumoKMOTZLm5qEVXFr0XJLRD04CblAFX70DEajaQmJSD7O4tOnkrW3e1Gs6XNyNyficFguDqLsRqwCuy4aLIPZNLlzi5oFeX7zi0LApdEkqtwi1BxwE1NcvQOwPmD2hMTE695zp3pBm42m7nsmsMyT3fyZRqK+5wdiSulUlmUqsDdHaWXkgxDhrWd2obJZMJoNKLX6zm04Tt8NRIXLlygZcuWNd21clGauEpISGDfvn3s27ePAwcOkJaWhqsS+jdQYtAb+eeff1ixYgWPPvpome0nJyfj6+t73elzrkV2drZ1NnZNxVCWPIe1RViXRYXF1bfffsvGjRvRaDRs377d5suQyWQ3hbhKSUnBZDLZDX0GBgaSkJBgZz9v3jxmz55dXd0rFb1eT2JiIjs2pqDYomD2X/Y/2sqagaHT6WxmYOW5upOizCbHNdumP5WBRRi5mTIAMGoCbOot4qr4Q8joFci5NBXZ7kU/WosbvipuHgaDgaTUdMZ/n09YWBizHm4EOb/TIExFbPRF6jdsXG1eHotgGOZ9ku9fceege/nfSENCQrh8+bLDuvlBvsS4QN+4q8lRnVVc5ebmlitWxZnElclk4qKHgc0+3nSRy+harM6RuFKpVBQUFBDlH0WT95uQ/U+2tZ3ahuW3cf7cOX6a4kmSQklCykVMpoonva0JLMIgKyuLgwcPsn//fvbv3090dDQASjn0qa9kVA8d9zZR4qY0M07Xjg37T/Ppp5/St2/fMtcTtHivLDnmKpPiHkKTyVRjwfOO0nDUhgkzZVHhMzljxgzeeOMNXnrppSpT0s5CyS+2tC/75ZdfZurUqdb/s7KyamTxTcuaggD16tWzGSaDIhFSWTlwNBqNjadjgHtHnoz9hqwkPcb/8jtVtucqyb2Qv1xdyC2RQNRynDKZDJVKhcFg4KyXnKnaYBp76Xn9v++tqm4eBoOBhJQE1AFqfAJ9aOnRit/OXyZMYWLFuQNQzeJKkiRMnnoyXJRo/YLLtZ2LiwteXl6kpaU5XDu0Bf6E5cUQaMix25cz3QBNJtM1hwMtOJO4MpvNhOcVMDi7EDdzXZu60jxXAMFyEzKzRBPv2hvQbvltxJ89wkd1A0hXKJiQHE2L/yZKOftzxmg08tNPP/Hmm29axa1cBj0jVEzs5k9mCyWnNUqGJaWgwkyhNpCIsDr4+6eQH5PPm2/O4dNPl5b5O0pOTsbHx6fSz0Xx0YfCwkKnEVeWspLPsNpEhb+pwsJChg8f7vQX/I3g5+eHQqGw81IlJSU5DOR3cXHBw8PD5lMT6PV6UqIPMKCDK52a1bWrLznL70aQyWQ27TWK6EUrfSHtfCDmUjRQeQv8WsTV+npuPBIcyDlv2xtA8eFAy48x2LcBXiYT3jIzOf+teVhVcVdGo5GLuedptKAR5tFmXBSu5BUUxbuZ4osy5FfXYseFhYVkZGTwfSs/+tSrw1l/92tvBPj7+yOTyfD09HRYP6HOA3ycmMxgcqxB4s44YzAhIaHcQwrO1HeTycRdGTnMTUmlg7yBtVwmkzm811oegn1V9fn7UiwzE4q+k9ooriweUGPcUXT/9f/cf+8itcETZzKZ2LJlCyazidB2oQx+fDAr33mRP8doGBaWw0pvN/5007Ivsh8Xun/K2f4/kaMLpo4imOkNZAxwPcKGDRuuuY/09PRK73te3tVJNzX5ezAYDGzatImnn36ajIwMa1ltpsIKaezYsXz//fdV0RenQa1W0759ezZv3mxTvnnzZrp06VJDvSoby4yPPPkRYp5ugLm//Q+xsuKtLBQXV0aPUApMMrQqGclnD1rLK+MHazQaMRQWEmY2El5oIMSnsU198bcby9+NAzuzK+Yynyclk5FYNMOzqm7UBoOBuqYTuJrNhFO0jwx10dIVrtlRQNUsZu2IwsJCYqIvopGDUpII8m11zW2USqVVVJX2YmC2ZmpXcO7EEWu5Mw0N5uTklPkAkiSJjz/+mIULFyJJklOtYWY2m3FXFl0fSvfSl76xYBFXGo8gZICHylztKT8qC8s15JZ9gafSMxlwOBFTSvWsCVoZGI1GmqgTePQRPzwne6LsraTV3aPI82lORsRg7vHuxsN1RkLzp8j3awkyOaPqjuJj//t4rZHEC13U/O/zt68Zq1sV4ionx9YTXVMYDAb2rPmc2wz72L1jm7WsNlNhH6DJZGLBggVs3LiRVq1a2QW0L1q0qNI6V5NMnTqV0aNH06FDBzp37sxnn31GTEwMkyZNqumuOcTiWjcrslBIWrxl9h6Iys54a9OeTMFauQ8nJT36xJNYMivp9fobXh/MaDSSlpJInY0JdPaUE/58D5v64teg5W9J4cLfKQpSs/Vk1kkgtGGLKrtRGwwGmifn8Jo8ji36pgCcDAxmgzwRhSEXi7wpLCys8uUs9Ho9OTEn+MmQQJZRRnS7xtfcxs/Pz/oAV6vVuLi42A1jmly8SS50wUutJ+viHujRFyh6MJbm7apOyjMcuGzZV9bZvsOHD6du3bo1GmdSHJPJxMrjRupoTTRoHWYtL+16sfTZxbMo/tDLVUZiQUGt9FxZJuIEy1IYmCtj66EC8iKLPCq1QVwZDAaGhaURHiTxkKRAp9RhRuJij6Ugk9HfwTZKmZK8OneREXQnXgm7mXdnAR9+8D4zXptZ6n4KCgqKZpVWUmiH0Wi0EVQ1La5eH5DCNm0gIVe2AffdeuLq+PHjtG3bFoATJ2wXBXam2IsbZfjw4aSmpvLGG28QHx9PixYtWL9+PWFhYdfeuAaw3KBGpaYwWy5jZ4TtMkQymazSF0EtKdaWBoSRokvBfV8SY4r160YxGo0kJKfx9PoCgoKC2PzK1ezslhxXFoo/jB49EMmhQ4eY37yQFlSt50prykYGyDVFXocUfz9+KdRxmymPwsJC1Go1er2+UodmS2LxjplSzoInpBrckMvLvhHL5XK8vb1tyjw9Pe2WiwGYHRzMHp2JZkcu0u+/MmfxXMXHx5f5IN69ezcRpz9lZjc1c3YUEh8fT926dWs0zqQ4+fn5rO5XB7lWzixPVyxTNq4lrvRuWub5eKOXyeiWlYGvr2819bhysMwUTEhIYMNtfvygVTJlSAaXoo8BtUNcGY1GvFRGGilkfCzrj67BqHJvG992Cn/sOcHPnVzx/Op/HDs2hDZt2pRqn5ubW2lhJ8WHBKFmxVVBQQGjQoqW+rmv4ApNuQU9V9u2bauKfjglTz75JE8++WRNd6NcFBYWkhR/mbt8QA0EN7jTZtmbkok/KwOFQmFdzw+gmaYZv+77ldwzV4MkK0tcWeJ8AgIczxR09L+6h5rw7uGcyz1nbaeysaxO4CErulHJ3IsCyNuE9sTt0Eba6PXEXviXyKatqvzmZbkZqbJiwBMyFX7X/IH7+vravQmXJq6yPFph5Bj7ig1fOAp+r26ys7OtcRqOiImJ4eBPL1PvnkBeTMtg0wWTNZ7SWW7g6enpKNwVKDQKvHRe1vLShJ+l3KDS8q2nOzJJokNaPKZ64dXQ28rDcn+4+O8/nPNwIUmp5IJKhV5dezxXBQUFeLuYAQUa73rXtC9Orqs3X/gFkiTl89R9fny04HU+XvFTqaI6Jyen0sRV8WB2qDlxJUkSqSkp3JGXz2kXNfXT9TXan8ri5o1Kv8XQ6/Uknz2AWiEjxyBD8rANaK/seCtH7Q6LHEbc0jiu7I62vhVVhmfDaDRyLvsojd6IxHWA7ZqCJcWVTa6rIAldCx2JhUUP0qrwXFlu/pvCNbzh602ST1EAeV2vloxIyOGu/AKyLvwFVH3STcvNaL1bPkNdfdjhbz+poSQ+Pj52ZS4uLg5n6QyPfIhzL54j6usoq9g1Go01HufjaJ1TC7m5uXz1xpMUPujHTx7udAwPJW9gIJdzi+LGnOUGnpmaiH7uebLeiSfQ9eqkmWuJK53akzGpmUxNy0CflVjrhgUt94cTZ6M5MusiAZmFzPXzYVfdokeTs4srs9lMRkYGLzYPYVRwIDnu9omby8JV4coj9Z9hSo6cifk5PNXgCitXrizVPjs7u9S6ilI83gqKznVNXD9Go5GMxBg+TUxmR8xlwtOKnh3O8tu8XsolriZNmkRsbGy5Gvz+++9ZtWrVDXVKUHEKCgqIS/6LKQF+fPJ/9s47zpGy/uPvycykZ7O72d739nqDox39QHoRAQGVnwURBBFQAVEQqQrqT4qgYkNREVFAEUGQDncc/Q6u99tek02yyaZNkvn9MTvJZnvJluN3n9drX6+7eZ555snMUz7Pt9rzQcj8tFNFrvqrBgsdRnZenYP/O3bqd2lpZ3R15WQQj8fJZxPGKgvVpZmi7JHI1adCEtc3dfGp0J5UO9lGPB5HURTec1l5PMeB4kyTlZ+1rmDeA0He3KudEKeLXG00xtlWaqeleMmI9XNzc4c9IQ9lR1WdW02FvQKTCNs2b0xdn2nV4HDPTyaT3HPbt7n/KA/Xen3UJCRqQwLJI/KRTVq8rtkiuaJzK7svtvDWqXEkQ5pQDUeudA9CSZD4fHuQz/t6SAS8+xy50ufE9u3b8TXHqKo34YonsKn7hkF7PB7H6+1ip8XEBrMJ2TL+WFTLc1ewatlNCAicPk/mH396cNh4c4qiZIV0JBKJIdejmZgPiqLQ7vFz2TNh/rlV4bbV+8a3Hw1jIleFhYUsXbqU0047jQcffJD33nuPlpYWPB4Pu3bt4umnn+b666+nqqqK++67j+XLR/dQ2o/sQXeJd6tNvGyz8l7O1KS9GQr9203KdorsBhKyAfeut1J9m8wk0e8/0BPgl+2dHOvN3PQHkgNBEFIb0sGqiy/Ew1RFNDXWVEhYFEXB6+7gsp4eLvf6qS0+MFUWLTuYJqvMts6dqbpT6Z0Wi8UIBAK0/auN1kdaOaL8iBHrFxYOzj2pYzgj9Uc/mSBwg4PortdT12aSXI2UIPwPv/0V3yz9gDKHgRrVxV0H/pJjg/lc6vMzz6+d2mdDCp9kMkk8oEkCA/HhkzT3R/9x/rk35yHfEWB32LHPkSt97OzYoZHdI03LeK2phcuatCCws32DjcfjhL1t/LG1g/s6ujBbJpZzN5K/iJZDb+Jzb9bR4YAf/vCHw64VAyVOE8FAeysdMyEtUhSFDreXh7Yn+XKTkY8Kkykp2kxLxSeDMdlc3XHHHVx11VU89NBD/OpXvxpkyO5wODjxxBP53e9+x8knnzwlHd2P4aFv2u+/F6e4wc2Cg07IKJdlecqMds3mfmo6QeDK0hLWOyRO3/Zh6nI0Gp2wl5y+WVTEg6wMR/BLQ6e+GXgtHo8j5JSCF5wGzS5oKk5liqLg62rF8L6PQ51GrCek+9cxv4N5P5hH2zttQJooTpXHoKIoNDfWk9cRJtJtYp5r3rB17Xb7iA4OJpMpFZC1P3YX5vCqPYk3sDV1bSbJ1XCbwWuvvUZBz6PUzTURTkh0fuI+MDo4SFrAJ7zrWRuUR7x/OpFMJvGEW/i904GSlDiqX9lIY0VPgSPn5CDlSnQHulFVddYFdh0JkUiEUCjEeWf0EksUUDWvBBohz5Skq8/YfTYjHo8T93VyUDRKT8xAozjxoJdtFccif+016iIK7978Li+++OKQ+2kwGBxSnT8e6PZWfr+fBx54gPPPP58FCxbMGLnaHt3Oop9rntaKV8Hj8VBcXIyiKFnzjpxujNnmqqioiBtuuIGPPvoIj8fDunXrePPNN9m+fTter5cnnnhiP7GaIegBKt9e3cjLf+rikJrPZpRPlUoQNPVEf4JlErRnhQ1pO5jJSAf0xTVP0jZwMT+TXA21+aQIV14522WZrlxto5kqm6vW7hDn/C3Ml9eUQ79NbalrDlI0wSH5odQ7mEpJSTQaJdDwEc3XONh+KTCClGwkqRUwbEDR9QUuHnHm0OVKG7LPpFH7UO9zz5493PTjm3hiZSkXlJXw7srriNk1+zNjUR0AxSZtE5kNsa4SiQRtuLk3P49nijPn6kiHIr3Mf5KfhfctpEHUUh3tK9IrXeq4a8c2th3o4tUjSvAVat60LotAsC/n3WxGPB6nMxDnm89H+FNDyaTashgsuGwuJEHiyIMtPPnrO4e0sQoGg5Meszq5+vOf/8zf/vY3fv3rXwMzpxYUk/Wp/5e3h+hurZ+x/mQLEzJoz83N5YADDuDwww9n7ty5+8wp6eOKaDRKe3s7vb29SJJEVVUmAZlKcjWw/fMMy3mjoZkzW9LeZtkgVzsKZd41mxAKMtMKDSW50gmXO9/MeRWl3FdXQCwWmzK1YJunDWOxkYLSTHuLUypOYl1rC3+RemjZuQGYWklJLBbD172Z98wm6g3WDKLXHxaLZUxjYiivpEMLD+d//AFOjqQjtWfDrm6iGDi2AoEA3/jGNwhFQiTCMnZbFfbytCTXXr6QqADkSwQDmrp4pjfwZDKJMxzmk4FeFgQyl+SRTu36OC8zJDAkVUoFLc7XvqJK0SWenh1vcXQ4wrJwlIKilXzV4eJ/8gvxdXeSSCRmnPyOhHg8zq6wjz/EzfzbMD5PwYEQBIGvVH2F31uP5pWDktx5RJgHHrh/UL1kMjmpA03/+997Twv43NKpjZ2ZUJMrisLp3Z38o7mNfza38bLZT7xze6psX8V+b8GPAaLRKI3b3+Sic52ce0zZIGnOVNlbDdV+Ze3R5CWTLMxLpJLnTmbCJhIJwr4O7iwt4CulxcSK0nF8RFEcMjWITrhKCheRl0jgSibwtjehqmrWT/WKorAzvp35P55P+PTMBc9gyqE1pEkXAnu0RWyqyFUikSCZTNJgbObi0mLuK8sbtm7/oKEjwWKxDJKcLK06g+92e/mMHGPXpg+AmU2D039sJZNJ7rn1WoKdDeSL+fzviv/l+vk3YjKk1Z9xZxGH1FRxdk05bU3p1EQziUQiQW1PhDvdHk7oSsdBMxgMI6YZ07/NFR1GPmxo4ji3JuXYVyRX+rcztG/iu91ebqlP4LKW81aBje0uK2093UB2yaLP58vqhp1IJGgWm6m6qorg8snbQuUb87HVno0iGFlVI2He+iQbN24cVG8ydle6vVU4FOSBTzdy6O8Xs/By7R3PlFowPxFgnqIwt+/bxLsbU2X7KvaTq48BotEoHd1ref+sStyfHRykMsMuagqQQd6KNL15ldNA/XZNWjMZm5x4PI6veStLYlGqowoleXNSZcPZo+jXXbYq/rOrhcdaOwh1To3HoKIozBN3YUkmmS8OXgjaE30kp3MLMHUnQ31RtMQDVCoKRerQLuGyLI85Ts5QqsGEyUlHVBtPod1vpa7PlN1V/+f+7sEH+EbdRt7/qp2Hf/xtyovKyTdm2qaYZTv2RBJzMklXp0auZnoBTyaTGBOamiZpSn+b0ewk9XJRzkEAjMlwqr19Afq3ywlr6syArRpJkEi+mKT5N8309mjvJFtzVlVVmpubs5pGJh6PYwkFMDSEKE6MLwzDcFBsJbiXXspuWWLu50u4/8e3DHoHkyFXukqw4YP/gMFA2GCg0ygSDvimLQdqfyiKkjL7SCHYlirbV7GfXH0MEI1GIdJGhaJQGs0kHCaTacqTbJtMppQkJGnM4adCARcactnctB4Y2aNrNMTjcTy+EAf+u4ULXvFiFdPqrOEMsvurCtd3m3l5TxxvtyfVl2xBN1A/qj3Auw3NfME92I7pxeJCvlxSxJYcbbGYanJ1eqeH/zS3cZ588JD19ATNY8VQRKxDKqVZEomEZtaovb/E7OWXXqIs8STXH1LFh2V51C46YNj7zntD5ajf7CLQpZGT2SC5eqvDyG8+iOEzj576RodOrlSzRoDNajjV3r6ASF+6HpfZjwoYSrVvlrM7B99aH72+7JIrfaPO5oatKAqf7mnno6Sba0PZmwNNc87kf8rK+GuBk2OO8Q0KbxQKhSZMonVytbv9ZS4rLaI0HuelphZ6mrZOe35KPcfnulIzT9ltfCu3hFVV5azP19brmZ6bk8F+crWPQ0/YfHR3F881t/HF3kUZ5VNtbwWahKO/9Oqf+SVsrM5hfU86NtpEJ0k8HmdPd5wr/xPhwYY5GWWjpQYBuGXHEk78c4id3uwbtSeTWrJcO9piJToGG7T6nC7et5hxO7QNYqpOhoqiEAqFqLZrz7FVDg6HYjAYyM3NHVe7Vqt1kN3P3yrLOa2ynP/kpYniTJArfZPctWsXHU/dhPeAXAKigRdqVqJYhzcufi+ynJ+9HWN7m3b6n+kFPJlM8vf5Bu49tYZ3itLzdTTJlf5dGu0Sd+Xn8XaplGpvX0A0GqWluZmHDi7mmKpy6su17AY/OLgLz/UOaoKa2jlbc3YqyFU8Hses9kkdzblZa9cq53B2/nEcGwpzTVGcjf/+JW1tbRl1BkZYHwv621uFhTYEVeXgSBSTCuF2zc5pOudDPB7H7/Px1/Jcvl/oosVspVsUCcmxae9LtjFpchWLxbISd2M/JgbdmLjGounRrVWZEouptrfS0Z/ELRGW0PlUJ+0b21PXJrr5xuPxVCqW0VLf6Oifb9BwmIGa62rYntieai9b0BfpPKnPdsRZNqjOypJV/KDLw+U9XsJ9tg5TIeqOxWK0Nu6l0qmRSLl40aA6BQUF45ZiDqUaLK85g6SSZE8glvJmmgmPwWg0it/v58kfX8Edxxr4YZeHr5qWcfGC74x4X0mJRrw6OjqAmV/AE4kEcTmOZJewWdJq/bFKrrqtEo86HWzM1+bDvkCu9Mj+9dvX02iU8YsiuS7tQJC0iHQ6jfQq6SwA2YA+77L5vROJBDZBm/+CdfwBREfC6XMu5VbrkZQkEvzsRIG//OnhjPKJ7LvhcBhVVYmEQ1wVcrO6sYWL2v0AJDx7gemdD4qi4G3dzapwhCNDYT6ZWMQTLW18ulmzt4vH47PaoWEkjGul/cMf/sBVV12VElHecMMNOBwOnE4nJ510UsqAeT+mD9FolM6m3VT1bao5dYdllE+H5AoySdyZVWfS/XQnsS27Uwv9ZCRXey0fMf/2OpIHZp5gR9p8UsSrAOxL7XQlNYKWTcmVPvEfnePkNlcewfzBRuTza07gjJ5elglxWnZ+BEzN4hWNRtneuolVeSV80VJEwpSbUS4IwoRj4wxUDR5ZeiSemz00P9jM7t27gZlJgxONRvnvY7/m/mODiAYBd9nJHL/khgwD9qFgroDll5cRq9Hs8GaaXCWTSaTHOmi9dSfLHctS10eTXOnjv8pSxaU+Pyd7tc12X1AL6urxjTtb+OCyrcx/vYQCi3Y4eazCzPnlpWxxZtebUydX2bThSiQS/HlJDheWFtPgyG4sQYNgoGvZ12gVK/nWf6O8vmZtRvlEUuHoxuxNH7yAyyogRZO8SjH35znZi2ZEPt3kKuqu51Z3N3c2uKnLO4AFMYUqMd2HmfbmnSjGTK5++MMf8vWvf52tW7dy9dVX87WvfY2HH36Y22+/nR/96Eds27aNm266aSr7uh9DIBaLUb/rFc4tL+HaXBcGW9qbThCEEQNFZhP9Sdy8vCTBGxy8+UWRlmbNxXeikitFUajMb8FYZaHG2ZNRNpzkqn/Z6YqJ7zR3cXFUWziyLbnq8Xt5LdfGEzkO5ILyQXVU0chn36jBdmeALQ3p0AXZRiwWY0t3I748E5vMjkFhGPLy8iYcSNZms2VIvCRBYv6cOubmG2jZlQ4oPN2qwWg0imB/j3+U5NCULMCz8oZhw0/0h8vhJnl4PtZ52neY6dOxEoux/oI4ni+ZqLKm5+to30v/JjW5C7ja6+eTwWDKa3S2Qx8r27dvR42rzC08CENfyi5HUkuBIyXS3ycb0MlVtiJ/62EiWmwyG80mRPvkAnsOhaTRwQfH3smHhxQSWRnJSEMXi8XGLQXXpV3RHa8AsD2Uy4d5dn6b62SvRSubTiNyRVHY3Z3kuId7uWtrFeaqg/nMEyG++M9Qqq/7qlH7mFfbhx9+mIceeojPfe5zvP/++6xcuZK//e1vnHfeeQAsXbqUyy+/fMo6uh9DIxqN0tazkZ1OI5FEpm2M2WyethhkkiQhiqK2uOdUkjQIeHKN7N3+LpVVVRMmFIlEgvO7/HwmCduMh2SUjUVytVQu4+TgGt6JJlPtZQvxeJyetj1c4/XSYRApPECLiC4IQsZmrdbOxRysZ2PrRs7irKyfDHWj0MDOAPVP1XPqqacOqlNQMHGVhSAI5OTk4PP5UtceOLKLA06089uOtcDnAW3DtNkGe6tOFaLRKK8YwJefx3bTAr44xujYda7lXNryBkWBGMlkEoPBgKIoI5L1qUSwuw3JoM1TS35p6vpo5EoQBERRRCpZiOOuHoIxWHN2cJ8gV/1zCgIsWLAgVXZmsJz7/K/w31ZNYpotctV/3mUj8nc8Hqe3t5dbWrqI22VsKxZOtotDImlWcZ3qIhFO8Prq1/n8hZ9PlQWDQfLyhg+70h+qqqYkV/8ytPGSLZ+DzXOoFpyY2j7A0qatp9MZ6yoej9Pq8fN6QwLnAbUYnAW8XuQiUZOgvaOdufa5+yy5GrPkqrGxkaOPPhqAQw45BEmSWLYsLcJevnz5IIO7/Zh6RCIR1m0wI/2xkTmtNRll06USBG2h15+niibOrSjjvPJSmrrfBiZmyJ1MJkkmkywRIhwTjlCRl05EPFyMKx068ZLztcjc+X0GktmWXPm6PUjv+liyOYxZ0ojFQIIROShC1VVV7JJ2AdlfvPTFR2yrx767lwNsmcbsOTk5kyYOA+2u3ioo5MriQjYXpOf8TEiu9m4JENwSJK9gaO/IoTC36nCu9vr5bDyMr0vr/0yqBrs79vCQ08FfLTYkS9qdfyySRkmSkI1mEiYLUq6Ez+/bJ9SCkUiEYDDIhV+Fb95URnk/c0XBqknf7QZtnmRrcx1IriaLeDyOz9vNUSh8IhTGmVs9+k0TQK21lrmeIg5+s4PeLc9nlI3H7ioSiaCqKtFolPesCu8U2emcewyVhedy/w2N/OlxjXhNt1pwm3kbC3++kNDKEAYMFHyhgJLzS9jbuTdVZ1/EmMmVoigZKiaj0ZghOZAkaZ+Y1B8n6K7oO7c28+GrPdTlnZRRPl3G7EM9ryQm4UgkUaLp7O7jnbSJRIJkLERBX7O20nSuvNHIgj42RVcF22WZZpec8qzMFhRFocGrcO7fw3x3Y11G3/oT22XWMoq8EVaZNQPqbJMr/b1+a249bdc6WJXfmVE+GamVDpvNliEF9eUV87rVQntemjBPp1F7IpHA6/XS8lQL9T+p54SaE0a/qQ8GSx6BvqEYbNHCSczkAt7p2cN9+Xn8uDgfgfQ7Hgu5kmWZBAnqHqhj4X0LcQfcs15ypaoqkUiEPds+ZHWlk5fm5qM60qRSdGghTRxidm2k+reTLXLV4/dy7QtR7nlfJGEaOtn5ZGEQDPzEXMSf6+IcIe3KmGfjSYWjexdu2LCBtr+1EXwhyKra4ygr05htZ2enliuxL2nydCAWi2GXO5DsEnlWAYNgoLBZoGibn7hHs+fcV8nVuIwwtmzZQnu75gGmqirbtm1LMWe32z3SrfsxBdCNiHWj4rq6uozy6ZRcQSa5uiQ8lyPdr/BEa5qQR6PRcdmAxeNxfK3bedpuIzcSx15YkSobjVzp5UpBIedVlCKpKj/rasVsnjPifeOBoii0elsxFhvJL07bW0iShM1mS4ngz6s4kR+99XdCosqm3gBWmyOryXUVRdFs78plTEYJuTytnhhI9CYKg8FATk4Ofr/mWXRI+Sqqt75DuT+Ct7ubvPz8lOfqdKiio9EoHY27OHeRRFfCMb7fKAg0RWXsVhVv5zaqOHFGJVdxfxdnJYJ0K4aMdzcWtZUkSUiChBxXiRsg4t1BIrFqKrtLLBZj9+7d1NbWTihAsW4X1rNrLV/P9/OhaKIkZ36q3OPM4dKefEKiyg1kR5U/0BYtW+Sq1d/FH+JmSnuLONkw9oTsdrsdi8WSSiE1GsSFp0HnfzipVuCJd9/hmFXHAdrvikajY/oOOrna8cHrsDfEorpFFJgKSBYkkSQJ1azS1t5CZUX1IGHKVEFRFC51dzLXHGOdUVMN3+0NcFCOn0e7p997MZsYF7k64YQTMljymWeeCaRtTPbnGJxeRKNROhq28ZWvOOhpMFJRkTaoNhgMo7pyZxv9yZWj8iCEba9QYw0Ri8UwGo3jltjE43HauzZxR6ELYzLJw3KaUI1VcuWyV5IXT1CUSNDdvo3CsuyJ7hVFYbe8g/k/nk9vRzrmjCRJGe/eXLaQcBysskDn9veoOegTxGKxrC1esViMlsad/KS6kIQg8GBx+jdmU3rpdDpT5Kq07Cg+8U4QgwEe27GevMNPSElSp2NRjkajRJvX8+QFVlp6Ybwxt2+pLWSbQ+Kcth0cwMyejq09Pfww3M37nvS3kiRpTOupLt3609YOlthjPGnrmXINQigUIpHQ0luVlw924hgNuvrY2LmNz0sBloYdSEJ6K0oU1vF2xE68J55aO3TbuIli4PfNxvdOJBI0hBqouqoKwTu2vc9oNFJaWorD4QC0vVMPNTMSQgXLacLIB8Uyuzf9K0WuQJNejUauVFVNkavjYy9x+3ccPGfQ7jEYDKz8xTz8JpHOxpeorPjKtMxjPQhziSHMXCVJc4F28O0VcwEvUmh2hEqZKMZMrvbu3TuV/diPCSAajbJn78u8dkgRlhVJ5H7kw2KxTDvZ1UmFoiiYqg6CbbCk0MB/du9i4aLFEyJXUW8zh1vDBKOZp/rRiGP/WFd/2tJOjSPBv1ztKQ+fyb4b3Q17sakBT8LAEjm9AMiynClJEUQaes0sdEborX8PpoBcdTWt4zA5QqtBwmlPk6tsLpB2uz11kFIlMy1hE5XWKKH69+FwTS0XiUSmjVxtj2zk6KpylvkTfH2c9+coEuZkkrjiS7U3U0j2esAAIdWEvkWO1bNTr5eMywjESPZ2T7lKRydHPp+P4uLicXuh6u86L6Z5Eody6ugf7KMqr4r2n7Sj9Cj4lvgoKioiHo9Pym5wIJnKxoYdj8dRA92IgRAOIXfEuoIgUFxcTH5+fgZJLCwsJJlMjq75MUjcWFrOh+YEh7XtyFjDgsHgqKr/aDRKMpkkGonQVpVgu8GEqzodtseRUPEDHr+mBZkOQqN76RaaE4CAqaAGAMVSAOzF1Dc3P/ZqwerqqTHW24+JIxqNonh2coQxTCiaedKdbpVg/+f6/X4UezlXyYVsNKscs+c9Fi5aPG6D50QiQW+3hQNeakFw1UE/s5qxLLSyLJNIJNgacLC7y0232EMdmqF8NjyFAM5o7eF/E0Gek9L2brrnpNlsTv3m35UWst6V4PCWLSwhu4tXNBrF2L6X38hdbAvYiB+ZHgfZzCtpMBhwOBz09GghMXaLBTSZPXi6tqXqRCKRQcbvU4FoNIo/6cYvivSO41uWlpbS0dHBoe5lOP7+JIHSQ+CcmTsdq6pKfa+JX++IoRYXc3Tf9bFKnXViE8EE9ELEP+WSK31Mq6qK1+ulsHBw2qfR7k8kEhjyI/gNAnLlQRnldtlO/J04fp8fny975Oq5//yH1a+/wvdvvSMrUv14PM4KXwf35bj5MDi83VNubi7FxcVDPlMnXboN4Ug41LmcaM87HGCJUl9fT21tLaCp+0aT7OlSq23rnuPeChcJQeCBeStS5ZfuTHKGs5EXezVngukgNHoom3fKc3Alk5QXaWYf7xaYuc1ezhy7wrWkHZumOo1btjEub8Gx/O3H9CEajVLnbuM37V18ocWVUTbdxuyDnmuQeMeej6fUykbPTmD8HoPxeJx1nQauei7CmviyjLKxLLS6BOVXHQdy4p9DfOQxptqdLPQ2nAZto5GcafWIvoj29xoMm3PolCR8Ri3wXzYlJYqiIPq15LdeQ2asnWxLkfoHFH28rIzLSot41pQ2sJ0uj8FIJMKxrV6ebG7j1GDp6DcA5eXluFwuZFkmUngYP3s7xhu704E3Z8IQPJlM8qyth/tOreHJ6jQpHa/k6s18K3fl51Eve6ZNcgXg8XjG7QUciURoqt/DfUuKObq6ko6KikF1XrlQoPt6B0IfcZ/snFUUhYqP7ubRA9ayZe3zWYltpigKYtQHQMQwOGmz2Wxmzpw5VFRUjEjmBEGgrKxs1NRUJ9ZdwmMt7VwthflozX9T1/uHWBgOOrny73mVY0JhakNxCqzpNctoKMCkgjmiqSinQ5Ibj8dxt27nZ648bi50QZ8jg8leSLcoEuy3dO2L0qsxS650lgykBmV/SYkuptzvMTh9iEajFKGJk5MFCzLKZopcZXjJRZbxj9/8A4fNAV9M50Ec66kxHo+nUpQMTH0zljb0OupSlZoFNWwXtJg62Rij+mR3mRRAwOSqSpXpUjGbzZbKWnCU6SAuaf0byY50jsFsQE+K7Yj2eSLaynH0K8927CbdVgSgqPAYovV/YU99JDX/p8NjUI/rVSYEma/EaXHNH/WeysrKlERNt3sBUg46MNgjejqQSCToTfYi2SWMvelvNV5ytTlH5h2ngxMDE0/oOxYkEokMohOPx+np6RmztFIPBbB7x3uoDhWDqFKSv2JQvYRdot1poDfQnHrOZKAoCp+bFyGGwBzfS6jqOSQSiQkH1tX7JCvaYUmR0/NCFEVKSkrIzc0ds/mBIAiUl5drhv49PUPWSVryaU4W4Up04N7yBpCOK9nb24vdPpjgQaa9Va1nB1eYA7yqHprZtqMc1E3kqJpN5XRIchVFIdC5m3MI0q6KWESt/we4DuWJTf9GCsQJxONIkjQjc3OyGLPkShAEKisr+f73v897773H+vXrWbduXepP//9+TA+SySSxaJRah3bCsFSn4/wMNKieTvRXQx1Xeiy5W/zYWnamro3nRBSPx/Esr2f+HXUolemTy1iNfVPhGPJF7EvseKV0vqrJIh6PE41EuHdOAbe58kgWFA/qW3+iOX/eSayIxrDHFYKBnqydDHWS95MyI6tyithYkmlvlW27O1EUU4v4mfPOZPf3dtP016aUzch0pMGJxbTgn2UW7bdbSgfnUdQhCALV1dUZm78syzgKrCy/rIw5X7EQi2qSmJk4HSeTSQo+Umm7dSeLw+nfMV5ytTBk5VKfnzk90VS7U4Ghxu140p7pbv6bd7p5/WvbqXtuHmZp8EHwB9X5XFBeyt5kdjIrhEIhrikq4ODaKl6Ts5PjM5FI8Fp1nAtLi/kgT1tr7HY78+fPJy8vb9xzTxAEKioqhiVJADsO+C6u/w3wm/d3ZUirRkqFE4vFNK/CSISlDo24mednhi7xFxTzQK6Tl8rF1D1TnbVAURSMvk5ud3fzzT2B1PsqKl3KAkWhzqzi7YtDty9KrsZMrpqbm/na177G3/72N8444wz+/Oc/YzQaOeCAAzL+9mN6EI1Gaa1fz2kLKvlsaTG2Oel3P1P2VqDZ5egnjIPzetj7DQc/Oy6c8jJraWkZc+A7RVEoKYtgrLRQYU+fpMYqjdHrnaBa+G5zF9dGtVNwtiRXnW07eMmhpb6xuWqAzE1RkqRUH8yFc6j9rYmFv+hl9569KIqSlcUrFotpEj6HQLfLjLEiTbKzaW/VHzpRMZlMHLqwglPnSjRu+zBVPtUqhWg0SmdbI89UOXnGZsVUsWDIeoIgUFNTkyFtA41cFeUVkjwin+ACB63NG4CZsbtKJBLcWrsT95dMHG1K29yM9XCkS0mXKUVc7fWz0K9JDqeTXIVCoTFLLPX7d+zYAcCiuYsH1ZFlmRxFoCCeIBnV1orJkqv29nYa+6TG3Wgb9WQ27GQyiaqquK2w0WwiatLWXJvNNil7ToPBQFVV1bBruFpdRd29i6n+XjVvv/t26nokEhn2HekkbMe6l3A5DcQS4Fh8YubvKSrjN3lOXiy0ofb9tqk+JCmKwnqPiVUP9/JIZ7/o9pY8vvqCzFG/76WjSyPu+6LH4JjJVUlJCd/5znfYunUrTzzxBF6vl5UrV3L44Yfz29/+dtYHrvu4IRaLsathNSGDgVZRwmLJTZXNlEpQh74wGEqW0iBJNFbZ2bZT28AURaG+vp7m5uZRF8x4LMKP3F082N7JfFeaNIyVXOkb1Dx7Df+jhDkwri0y2ZBcKYpCuKuBm90evtLpw9KXKHngppiyuxIEClfWUHBaAR80fABkZ8GIxWK0t7fTcE8DLb9o4YDyNMmeKjF6f7urP50W47n/sWJoTCeVnWrVYDQaZVvbDn6Rl8uNLheidbBBtcFgoLa2dsh0PLIsYzba+VK7j5vdHqLt0+chNRDJZBJ7X7BMgz39O8YqudJT4OxyHoXjrh6+/XZuqt2pwHA2dWOVXun3792p2VL1T3sD2nezWq1c0ijxalMLS9yTzy+oqip7O/bS7DKzMhzhxCZNRTYZcqX354JGL/d3dLFQ1iTGk1Ez6jAYDFRXVw+5jheZi5BNMoIk8Nq6lzLKdNXfQOjXn294l8MrK/hSTiXImW3XVa3k+LYeVuz043NPT9aCWCxGY1cPbzQk6DDPTRcIAm+VlLJjeR673PXAx1xy1R9HH300Dz30EDt37sRqtXL55Zdn5B3bj6lHNBpl51477bfsoPSdzNxSM02u9OfHzQV8uaSYb5cUsrf5jYw6Pp+PnTt34vP5hpTgqKpKxN3I3ESClcEwFRXplC5jPdWnpEYF2sJXYNZOYtmSXAV9vYjv+pi/Ld3esOQKMB5hpOQzJWzu3Qxkj1x17N3KIVKcub1O7HJapTBVkitRFFO/6/GCIs4qL+V96/ZU+XRIrlrb3XS/3o1hl4TBkCkpEEWROXPmDHv61zfAk1oUzg/0YnBrEs2ZWMATiQRrisw8abcRc6RJ63g2aUmSMOfk04tAT58N0FRJHSIRLXlw/wTCoM3nsRCgaDSK3+fj5BtsXHF3DSUlmSRQl/wokiZt1G2aJkOu4vE47Z6d9DqN7JZlHGSPXC1RIhwfClOUo60xk/VC1iGKIjU1NYMOSKIg8s3QMh7b1MjJvjcz1s7hNAL69Q3+vaiiQNBUO6hOrq2Iv94d4t4ft9Ha5QOmnlwpisLuit0s/PlCAgsz1ZrSURIl55ewJ7gnVXdfw4TI1dq1a7nkkkuYP38+wWCQX/ziF6N6OuxHdhGNRtm7ey/uhhhF5kxX5pkmV6lNTRCYE1ZZEo2S8A2Ok5ZIJGhubqahoWHQRE4mk/S2aaqDtiDY7OmNZ6ySK4PBoJ2ES+aw3SizKc9C0O/OmuRqRzd8+u9h7q4f3lam/wZ/qJjPQR1BTo5rNmjZICGxWAxT6zusudjGH07JbG8qDUB16VXY6mKvUabbmpZoTIfkytfoo/UPrczdMTejTJIk5syZMyKx1Amwr8/039DTnGp3upFMJPhDUS63FroIO9JjZbzkqsvaxZLfLMH4P9rcmCrJlc/n47qvfo5vfeUzKVW/jtFCCYBGzvZsXc3bDitvuOw4CjIzJlitVkRRJNmXSsaU1IjQZOasoiiUeeq5t6OL67u92ITJ5yyMx+MoisLdayPc/noUsUiTwGWLXOlt1dbWDlrvjq49gOUFIseVRdmzZ0/qeiAQGHRQ1c0GotEoW3+3le3f3s6nqz6dUUefK3oaHD1H8FSSKz2AqNPeg2SXKLBkvrc5QSvFW/3k+1qmvC9ThTGTq7a2Nn784x+zcOFCzjnnHHJycli7di3vvvsul19++T4Xg2JfRyQSYdcuLRHw3LnpDcZoNGZ1gk8E/Q2pr/AV81hrB/NHSOodDAbZuXNnhlt3PB6nw7ONp+023pKtGcah4/GAk2UZ2VHAeeWlXFFSRGfblqyc6uPxOC09LRhLMlPfDJRcGY3G1EZ5umMFfwx1c56iGdZnY8GIRqO0xHfztN3GVnNagikIQtY9BftDJ/CH5q7kV+2dXN3amfp2eoLYqYDubZbn28jZCyWWVKZ/syzLzJkzZ1RSqX+jHmMejZJET1JzP5+J03Gvt4PjwmFWhcIU5WtEQxCEca2nsixTbNK+dUGudm0qyFUikWDzrnUc9+18LrvOyYtPP55RPlpYBj2noFK/jp+3d3JRWxCHMTN0iM1mQ5IktjvtXGLP5/FC7VtNllxZAt0cGI3yRtDAOW6NxE5m/sXjcbp93TwhWvhJu4TcFwAz22uvJEnU1tZmkO1Y5dHEk7CwQGTLmmcz+jTwN+n2VrvWv8nnFyc5wOHg4LrMJOe6YKSktATRJtLcoe0rUzkf9DX4jq52nmpu5WSpBEhHILgiDC+Z/Rwb1CSk2QidMd0YVxDRsrIyvvSlL3HWWWelAjRu2LAho97y5cuHaWE/sgVVVYmEQ5x6Xg/HdxZQU5221ZhJY3YdgiBgNpsJh8MIxUuhdT2lonfEyOiqqtLW1obP56O8vJxEIsHeyF7+WOii1qRwZ7+64/GENJlMRKNRKiMKVkGlJ7J70pIrPahdfe4u5v9oPoG2tEh7KImD3W7H5/ORt+BIaLmP6hyVt7s7hrQHGg/0kATbcgM8XOjiJNGObhZqNBqnNEK/ftqdM+9Elu35JUm7yqst9RRX1Kb6NRXkTo9HdZxzNz/8jJUXTdq714nVWMaGLtFcW2rlxoIyDrIprOjX9nQeFAOdjdzq7iakqOw+WlPXjNduR5IkFufU8vaGJuR4ko19QTqzjUgkQmPbu7zhtLFXUTjy5cdQ1a+kxtloYRl0Jw6LZyer5AjG8OD4ZGazmVgsRnNeHe+I20iEE3yLtAH5RMa0oiiIYQ89DgPPzMnHXpJAUZRJh2Fo8bZQdWUVakJFErW2smFzNRCyLFNYWJiSKCVlO4/aynndqSDufAO4OlU3GAxmHC50e6vIluf43VkWtgXNxAe8Q4fDgdvtpvwEN4s+t4hk++vA5VMqydXHQrUxTrEi0NYXSshisRAKhUjaSiCxCVtS827UDeyn4v1OFca8isTjcRobG7njjjs47LDDWLFiBQceeGDG34oVg+OV7Ef2EY/Hqd/5Ji/W5fHGESWUVNakymZaJahDJ3m2OVo8lUX5akZMoeEQDofZtWsXXV1dWEN+jgiHKQtmngbHQ670undu9vJEazs5Xu+kyZV+/1JrB7ZEkuXG9CI0VN/0d2HOL6ejF8KCQMf21ZNevPR+1EZDrAxHqDCmgzFO9TjQc1cKjmI8EQGDIODdnjZqn6pgovo7e2CZg2Oqymko0iRXOTk54x4XeeYyLMkkRtLjYbrVD71d2sncFxVSxGG8YVQkScKWV4pNVTGKAr2+zimRXEWjUeydHVzv8fJ5f4BPz+3lrffezKgzUhoX/dsVxvvUTnmDY/PpaavqHHW0PdqG70Vfqnyi81ZRFDyyn1ZJorQxSPfL3XR3d09KGpJIJAj4OhAbQsjtidS3myqtwUCP15bCOt61mPGWKRm2VgPtrnRytcmxkx+68liXl6mG1T2ajUYjuX2BUGMG7TtN5VxQFIWg30uxTXtv9lJN+2IymbTDT64W4DRHDGfcsy9hf27BfRDRaJRAwzo+IwdoTEjYTGl7pNlCrvR+KPnz+aSlmOYCA5/Z+T5nln5yTPcHg0EiTQ6WvbUBtfa41PWxxrjSoUtP9kTzcO9poqsiytxJnur1Sf7FJi8PRGL8x3FkRv8Gor+E6vryEtbnynym4y3q4udNSlKix3v6SsBHcVLgzaXHpcqmI+Ce2WxGURTWCrmEHArN3vdZyP8AGrnq71WYLUSjUSLhMF1miaBooKBAc+UfLyExGo0sLfgErfc9SWvYDH3ZixRFmTJHgKHgDsb49QcxRLODw/uuTYRcIduIJ0EyQMTXMSXkKhKJsG6PRNOj7Vx5RRFXLK+kcPdvOPKwo1N1wuEw4XB4yHUoGo1qxuUVsNFoRKrJtBXV54koitTm1eJ5wYMkSSmJ1XgCEPdHLBbjjTKVn7mK+GZnN5eLPYTbd0Jx8YTbjMfjuLydfJh00+YT8aBJ7KdKWmw0GlNSeICj53yaqnXfY2UgzH/fXs2qE08DNDLV/33FYjHNu7ZEpN5q4avOhRntOhyOlAnBEcJS7qz/C41ekRjpmGRTIclVFIXO1s38OjcHVyzOgr7o7JIkIUkS7S4Hq2zlmMuS3N3vntmyv40F+3ML7oOIRqPkdOzmJouXV9yF0C9kyXRuDCNBl9aoRgctJjtxh8KmPZs5k7GRK4Dn6w28+GKE7373wNS18aqa9IXzn6FDeeSR7Vx8sZmVk1AxQPoE7ZI1kmXOHxydvT90O7hEIoEhaUIVVPyJtNHoRL9ZLBbD01rPcv30VzX1YRj6w2w2EwgEeMxVzoaCHkr8AU7pK5sqo/ZoNIqncRsvNbXQKIlEl68EJjYu8quX8rO3Y0CM60IhrFbrtEuu1obbeeLUGqQOKUWuJqIWRBD4pT2HoFmkxl8/ZWrBXY3tvLk3wSeCBbgLVczFQdxud0biYI/HQ8UQKW0ikQgNOz/i7ppC4oLAA1WZwV/7k6t8i8DOq+zkmWFHwI8jJ3dSkqv8uEKFIlClJjhpkcxTnr3A0SiKMmFylQh0ARBIGFP9nko4nU46OzX7wDzXwSz0JCmUEzz+0TPQR66SySThcBir1ZqSWu1ev5pvBvy8EzNz0OHnZbSpByyVZRln8SLMPSolljiNqgqCMGWR0RVFod2zlZ/n5eKMJ/hVn8evLMuaGrRoId0tIiZBIBjwY3c49zmj9v1W6PsgotEojrCmTghaK1PXzWbzrHEskGU51ZclXUvYfcduuj/sHlcb+kLSP/XNRMlVvC5Ozbdr2OnSPPUms/koikIymaTIqkkHTAXpGDdDETZBEFIbxydCdbza0Mx5rZr6ZDILRiwWw1+/HhXoCguI1txU2XSQbH3RdVkPJvBRgNbtaduzqVQL9jZvxqaq5PiSSLJG4sc7LiRJwm63p9Qtusp6uhdwd68byS4hWTKDz44Hev1/5tn5q9OBJ9Q6ZZKrFqUFySlRV/Y5vrrTj/TgXp566qmMesOFZYhEImzfu5HyzjDF4TguR2ZIAF0qIUkSJkc+9kKZzlwTPW5trZvonFUUhW+0eXiuuY2TQmFiQKSnNVU20TYJabG9Qqo216aaXGVIggWBhrwjeWh9jFfe3TJkSAadXIW2vsgJoTDnN8dw2soz2tTXJVmWcVYv0Z5jgmiPtvZO1XxQFAXB38k5gSCHetPP0LOLFBcu5u9Nrbzc1IqvZeoN7KcCs2Mn3o9xIRqNYpN9qIBalD79zQZjdh2CIKQWy2OKlnGUGqOge8vYG1BVhAsjzL+jDrEgPUzHu4nq9U25JuxL7ASsmoHkZL2Pujr28p3KIm515WMurgFG3hT1Ray4/DBi/jiNHs2LZ7Lk6pXAHg4qLeeynPSiKQjCtKQ/0gncKdWn0HBvA3ue3pPaABVFmRLpSTQaJd6lLbZdSlrdOt7fq9dfdmEJK2+qYXvL68D0kytXu0zbLTsp2jD+AKID65/gjnCpz4+lN/v5BXV3/txLrSz82UIoK6DHchnPbIvzxBNPDHped3fmQUr38ty2rZtnv7OHgtcOGOQBrP8Og8GAapA5u7yUC8pLafPuTPVhvEgmk8RiMe5ZG+V/10a51FnEwbVVfCTVAxPfsBOJBOsdHXyurJhnCrVxONXG1iaTKeMZieOu5/pmKxuXiGzfno4zp6fC0cmV07cJgE7LvIz2zGZzqj1ZlrHlFnKPNYcbCl00Nr4LTC25cnl93O7u5vymNDHUyZUomsjrSeBMJol07puxrvaTq30QvQE/Vy4t5piqcmI1aaPQ2aaP1sne4fleXvyCjYvr3GOeIGrYDUUSxkoL5QUTl1yJoojBYOAYOYcbmrr4QVSTUExm44/H47R1buINq4Xn7FZM1vxR+6a/i9zFn6D8niDnP+bH5/NNyqg9Fouxq7eLuFmk05AOSTAVOQWHgi65qqio4IS5Zi5ZnqCjYeqCiSaTSS3woKGeX+fmsN6u/WbdCHo80MlVxWIDvXPtBHs/AqafXB0Xfxv3RSauLEwbgo93k9Z/+yntCa72+skNhrNObCORCA0tuygiiaSqLCqo5pRTTsHhcNDS0sLqtasz6g8My6B7h+lpb+bPz0y23d8uUQ9Fka8kKIzHCQW1pOQTIVeKouD3+/n5u1GufzEKSe1AEFaDqfLxQvdc88lhNplMePvm/VSTK0EQMnNkGmXKvlZG4RmFPPfBc6nr4XA4ZWsVi8XwlkVokiSkulUZ7fU3ktfXrudzbDxjt9Hi0QIdTxWhicVivNyew7F/6OXFSGaA6LQTUgVHPtTLTq+QumdfwseKXNXU1KSMCvW/7373uxl1Ghsb+eQnP4nNZqOgoICrr7560EfbuHEjq1atwmKxUF5ezu233z5rYmwkk0l27nqTsCDQazAwp+6oVNlsI1d6f0yVK3jDYmbjYidr3lo9yl0awu17+HtLO3fu7aC6OH3imohERpZlqnLruDAe5vCkZgs0WcmV1N3FrV0ePt+WzmA/0uJqNpsRBAGrzUbtmbWUXVTGO7vemTS5Ut5R2Pm9nRwQSttbTZfdnW4IK4oiD51l4d7TLHh3piPxZ1s1qM/T5wxJfp6Xy5o8TVo30TEBcFiXxM1uD3O6J77ZTgZyvC93npze6Ma7SespcH7edgCOu3p43V+WdclVNBol1riT/za38urOJkRbKWazmbMuPppjf1LHy+2/zqifSCQygozq4zzWvg3JMDjtzUCpuyiK/HSrl1eaWinyTzwFjqIo7Onaw5yb5jDn6jmc5s1jTUMTpzRr68BENmyduB7ZGub+ji4OCjtTfZ5q9FcNGg1GanqrEd/pJrzjrYx6XV2aPdg7G9/h3rlFnF5ZRnLR0Rl1+ieI1ufDkhY4cZuHWLe2301FOAY9gOjuTj+rGxOEctNEW5dcAWwrKWPnAXlsDtUD+57katxUe+/evcTjcebNyxQx7ty5E1mWqampyVbfJoTbb7+dSy+9NPX//gMokUhwxhlnUFhYyJo1a/B4PHzpS19CVVUeeOABAHp6ejjppJM4/vjjee+999ixYwcXXXQRNpuNa6+9dtp/z0BEo1GaW5JsvHYLhxw1D9MD2kYqCMK0GDGPB/qCqeTO4cZCF35RRPnT7ZgkM0ceeeSI98bce5inKPR2CkjGNFmYSOwko9GIraQOdoLLAk2R3knbXAV9cfI2+ihzFKeuj7Qp6nZXwWAQ55FO4mVxNnR8yBmxMybUh2QySSKRYE50N0EhztKidCDZ6RwHFouFWCzGfcVFvFEo8YmOdSzpK8s2udIXevemCD1NPRQfqjlHTOT36gv4/Gghnww08UpQiy6uv9fp2ChVVWW7PUqXw4YHK/qKOhGyKIoigs1FLwK+kH9KJFfR9q1gAHfUDH2S0VOXOvixbEFR4rS0NlNeljZk93g8qQCVkUgEd2cr1huKOF/Jp7wsc64MjPkmiiI9qgmIoPZqtk0TJVcd3TuxzrUi+JNYfEU4kyq2PsnVRMiV3o/KSJjjQ2FeMRWl+jzVsFqtGAyGFHm+K3cRS4tWsybip6enJ0W+9Gj57258l15jL7mFuTisZal2BEHIILR67Lf2XSt47LHHuOQSKyczNdIifWy2HdbGorMWEew7YIiiiCAIqXU0OTdJybElNO5qTN033XHoJoNx9/Kiiy5i7dq1g66/8847XHTRRdno06TgcDgoKSlJ/fUnVy+88AJbtmzhkUceYcWKFZx44oncfffd/Pa3v6WnR5NA/OUvfyESifDwww+zdOlSzj33XG688UbuueeeWSG9SiaT7N69G1VRKbKlCa7FYpkWVdB4oLvVIpk5NyqzMhzhueVR/vaTq3n55ZdHvDferRmxepTMjXMionej0Yi9oJKNBonVFjPdbdsmLLnST12bPBLnPR7mT+6x5zzUN5DjYmY+2+HjuO71KXfn8SIWi6GqKj84xM1bX7GxuDC9sE+nx2jqWQYHMYOAT0ynQMm2x2A0GkVVVZr+20TL71s4vEzzr5sI4dY3k2SfrVouaQnkdKkfVFVldaHIbQUuGp3p7zeRTVqWZboWailw6kuz7y0YiUQQfQ0AdJObur5ixVV8q8vL021tbHr2dxn3hMPhVITwaDTK9m3/xSOJbDfJ5LnSkitRFAfNHUmSCAt9CeAjPmBikgtFUajwNHJfRxdXeQIYcrRI4FZBI/4TWQf0e/6xQ+D216MEnItSfZ5qCIKQIb2SF2r+uUdUGFi39pVB9beu2creu/ZyevfpGdftdvug/UKWZUpLtcCu/VPgZHvf07+jMzeGaBUpsWnfub/9F8BCIZfirX7m9qSTgmcjddl0Ydzkav369Rx11FGDrh9++OF8+OGH2ejTpPDjH/8Yl8vFgQceyA9/+MOMhfKtt95i6dKlqRxKAKeccgrRaJQPPvggVWfVqlUZp+FTTjmF1tZW6uvrh3xmNBqlp6cn428qoae9qaurS12bTcbs/aH365NLb+GnASO1TgMv/o+R0DPf5V//eWrY+xqjDfzLbmOHtd9CIssTIpCyLGMQRb5WXswVJUU0uTdPePPRI0W39Gqpb/KK0rZOoy2u+rtYZajje6EeDgxN3GMwFovR2b6bx8ty+bfNir1mesMwDHzW4dJy/tPUypWNnamybKfBiUajBLxuLl0a46wFEmWl2kY5UeN9WZYRXNU0ShKdzjTBnS71QyKRYHEoynG9IQplTQKqn97HC0mSqJC1jafE6suqWlBPW/NmURffLnSxKTcddkE15XJIZC4FiSR17pcHbX4ej7YxhsNhHI07eLq5lW/s7UU0pOeKzWYb9JslSWJ1noOv2PN5wzbx/IKKomDp6eaEUJglXpH24mVUfmTiPK926NalIeOB3o9/xZP8pF0iVKTFjpqutGP9yZViK6E55qDDKNG+598Z9WKxGF8v38Ttx5s4+sBMNezAoKSgHVJKy0oRbSJ+RTvc6vZl2YRuf/dIZxtPNbeysi/ptT6P9fd4piGHl8x+vqKkg0/vS3ZX4yZXgiCkvBH6w+/Pvih6vPjGN77BY489xquvvsqVV17JfffdxxVXXJEqb29vp7i4OOOevLw8jEZjyhV7qDr6/4eLMH7XXXfhdDpTf5WVlUPWyxbmHbWFq28qY35tWkIx2+ytdOj9iubNp/WkP+CpOh2DINCwxMkf+RMPP/3wkPdtNHu5qdDFu2VpdcFE06nok7Y8FGdhNEbU3zqpmDkAzZX1zP/RfHrn9Q56znDQ34WlWgueOMcWhj4vqon0Y2/DGh7Mc/Kj/DxMdhcwfZ6COlJJX2uOpjIeZ16OghLTpAJ6GpxsIRqN0rX3A+441cIj51oxm7X3OZlxESsu5YzKMm6sKySR0Bbu6VrAk8kkl3j9PNDpZq5FszuZqPRDkiROizh5u76Jq5u7s0qu9M1wb57K83YbAWdhRrnxaG2NPWNOgndfzdzg/X4/iqIQi8Ww+XdTq8SpjJZk1BnqYCiKIh9YKnm30M47grZNJRKJcZP1WCyGGO4jeKIDU56T3LOLsa6ypt7ReMeo3o+8L+RR+91asKf7PB0YKHX6a9lcTqksZ3u1O+O7b/voTS5cJvL9Y01UDYhT2V+jo8NoNGJ2uVn0i0WYzkvPgWzPB0VR6PV3U22COiVOQZkWCFgf+/oaZnRpfXb1y4CxL9ldjZtcHXPMMdx1110ZRCqRSHDXXXdx9NFHj3DnxHDrrbcOMlIf+Pf+++8D8K1vfYtVq1axfPlyLrnkEn71q1/x0EMPpU5PwJCnwoEBJQfW0Sf0cCfKG264Ab/fn/pramqa9O8eDtGQj9dKrbwyN5/CqvSEme3kCiApWWk77HtsP/wHvDe/DFOxiYdfe5i/PfIHGLBolkfCHBEO41L6GXBOcBPV7/v6tgiPt7ZT1h2YVMwcgGU2X1/qm8wYLSPBYDBgtVpxzV9JOKnSaZdxt2yasOQKdwOfDgQ5tDt9/3R5CurQpYnO2gMJKSpWWaB717pUebbsrnRX/s3edzi8ppLLyopTdj8TJZNGo5GqyoOxJZNUKHHc7duAaZRcxePkGrXN0OjUDnAT/S2SJGE2u7CpKlYhlpKwZgO6OvZLbd1c5/FSl5eZPzZesJjX1AJuLXbxaujRQfd3dHSgqiolaEbWicLFGeVD5dgURZFqqml7tA36RXAZL2lUFAW37GedyYTP6qS6oBrvG148L3rw+rypOuNBPB7H3+NDbo+gdkQpzy1J9Xk6YDAYMsjRkpqTMagqThts27I5df3Dpn9yTFUFNzkKSJozk8sPtZbKskx1qSYBVw2ghHxA9ueDoigE27TwGuG4irEvOnv/sS/LMpYSTTOTZ0sS7+vDvkSuxn1M+slPfsKxxx7LggULOOaYYwBYvXo1PT09vPLKYJ3vZHHllVfy2c9+dsQ6wxnRH364ZpOxa9cuXC4XJSUlvPPOOxl1vF4viqKkpFMlJSWDJFR6MMuBEi0dJpNp2lQxLZte55vdPrYKEvOWa79Pz/M2GzEU6VMqjuf+ooP4wT9/wJaXNnF86a9Q/voSpvMeJGnUyFT4I5llwb0YD0/bCkxWctWcLOTF3R7aCxIsmOAk1SVe1zW6mR9I8nxxOuL8WBZXm81GyO7knPIyWswyl9e/yLxlx467H7FYjGJ3G5dEunnFm1ZzT3eEft2RIqKqPGnIoT1fxNT8MsWLNYeFbKXB0fPA+SOaLYgxnn7XEx0XkiRhtTg44uE2GrsC+G+OU1w+fZIrJRriT+sV8i0CpceWpfo0EUiShGR3QQ/YxDhxBh8aJ4poNEp3dzdX3+dmnkvk54+fjMlkSgXTBfDMPY2nk68j21R27N3M/Nolqft9Ph+xaJQ1dWY8qoSt7tBUmZ7kfSBEUaTOWofnBQ8lS9KSrng8PmYSo0tOXylVuS+/mHM8RhaYHdzYFaDUohBu3w35rgmRq5DXzYeqG0KwxWwjyfSRK9BUg7oGqaLyVP7z7j2UGxTu3v0vFi9dBoBbbCEgGglKuRn3DqUSBJ1cLeGl1xspNsGbru04567Musegoii0uDfzq9wcHD0JDugbo/3HvizLGItqOLaqHK8o8pOOnVRWLN6nyNW4JVeLFy9mw4YNXHDBBXR2dhIIBPjiF7/Itm3bWLp0adY7WFBQwMKFC0f8G25DWb9+PUDKSO+II45g06ZNKWM90IzcTSYTBx98cKrOG2+8kbHAvvDCC5SVlc24JyRA7853+VJPgHN39iLL2qZitVpnnTG7DlEUh9z8nEYnP7ngJ/zoqvM5pkpkqbGe1a/8D8aO9wD4w4dxrn4uAsXpRXqiBFK3Y1nNYZz8SIgXWqyTllwVmLX7zQU1wNhzHuqn9PwQ2JJJeny76e3tHfeJPBqNYotoh4CwZebIFaQJ9GPWEv7kzOGlSNoFP1uSK32BP6alh7X1TXyyQ9sg9DhmE4E+nl7qLucfW+M0dXgznjXVaHS3c//ptdx0aAWWXE2yMBlyFXbY+Xmuk39WaFKNbKkGI5EITU1NdPaq7I4VIFlzMZlMKU9AgAXLL+bCziDnvNbMK/96elAbO7a/xsOFudxQ6MJec2Dq+nBrlyRJ1Jm97LrKzh+OaUldH486X1ff5ccVKhWFPFmTkHxynoFzFskonnpgYpKriFeL8B5NQFJMR5afLvQnSAbRiFeoAcDaqoVkiMViXNncymMt7ZzozLSRHkolCPQF7xRxB7X5FGrVYtZNheSqObSHX+Tl8oQr06a2/79NltxUSvXWjg3AvmVzNaHRUFZWxp133pntvkwKb731Fm+//TbHH388TqeT9957j29961ucddZZVFVpud9OPvlkFi9ezBe+8AX+93//l+7ubq677jouvfTS1On6wgsv5LbbbuOiiy7ixhtvZOfOndx5553cfPPNs4LAxFs3AtCFC10pOFuN2XUMl7NNEAROu/RmfvknCy0Fr/JcoZ1N23/ATZ2n0e3WAgdOJvVN/+fIsoxapVJzfQ172TthchWPxwkHfORb+vL59Ymux0r8dCJydkse5/u38LpPiyDd1dU1rGR0IPQTuV3SHCfU/HSm+5kIx6E/Mz++iHUvvES+mA9naWXZ8hjUCU9OohuHqmK1aHaNk5HY6veWlpayadOmlMRatzGa6vne5G5CtIkIooC5L9zIZNSCSbuTX8ecWBNJzugLKZGNDT8SibC1dSuWOgsVpRWpfubm5qYjsYtG7MarufpP15CX9xwXX3Ftxnzd3dhCtdeHNd+GqV9Mr+HWLlEUMdscWAtl2qICuvx7PORKJwXXtXmo7lV5qfqLAPjiRoqECGFfc0a98bQb82ljxRc1pNTT0xkiQJIkrFZryhuz98BLOPabV/J2e5CXr/TSsmszFxQJGGIxDEvOpf9qN5QaFtLrqyduBYIkuuuB7B82FEUhJ9DDuaYgsZ70GBkouQK4c4eHFdYYL1t9qXv3FYxp5m3YsIGlS5diMBjYsGHDiHWXL18+YvlUwWQy8be//Y3bbruNaDRKdXU1l156Kddff32qjiiKPPvss1xxxRUcddRRWCwWLrzwQn7605+m6jidTl588UW+/vWvc8ghh5CXl8c111zDNddcMxM/axC8SiN+k4GQvSZ1bbbaW+mwWCz4fL5hy0/44rf5xb8FjMq7nBvsxej+Cwt/Wo63vYiCwrRn0mQ2UqPRiMVpwV5mJ9KqebFNJGaKoig0tq7nD8WFlEUVPjVOWxlRFDXpUt4SVu/awEe9UU5AC/rncDjGRJR1Fdml8wswGFS+kTOXmr6ymSBXurTsmOJjeOTmR7DUWqBv2ulpcCarMtEX+EJJcyAQCzRSO5nfq38z13KBlStraJbXAP+T8pCaakmEwRel/dadWAoLoU+4MBnJVVF+LZ+pD5CTTBL0e7IiudJt3VqSq6n7fh2lrZodl9FoxGw2YzKZ0lLFVcdTVFREZ2cnL730Eqefnlbp79jq4dk/NXPhhRdCv9Buw230oiiiOHM5uaocg6ry+2gEk8k8bnKlqir3vBWl3K5y+GFa6Jr7avJ4N1/mzI7dLGZikqttsW18tqyYef44n0EjVtN9+HY6nSlyZZ17FO7z5jN3Ljz/7vNUt27G4BBoCptJWNJrqMViGXYu6tffys/l+QIT9p69VJBdaZEeyqbW18NVdPPfnnR8vv5jX/+3NWTEaY6AT5NeTtfBJxsY00w+8MADaW9vp6ioiAMPPBBBEIY0lhQEYcY8Bg866CDefvvtUetVVVXxzDPPjFhn2bJlvPHGGyPWmSk8UC1xo6mCi/yl6FkFZzu5Ggth+Ponr6Pw6b/zq0d/xG0X5uAXRXILIdeZC5ARXG4iMBqNHGJzcVhzF6UxbYwGg8Fx2wMpikKbZxurrRbKRImz+8jZePpms9kwLDiVVTc9RE6Oh098X1ssmpqamDdv3qiET1EUOrwdJG0iSaC2VrO9m25PQR06uaqbU8tXVsgsK25HCfUg94XRiEajk5auRqNRFCXGo3VOapMJ5lVoruXZkFxVF0XYVGxH9aVT0MRisSknV5a9r9H1JRPvdKRVp5MhV46cMm50d2MQBF71dWZlLdbjHOUqHkriSZaLGpnVHRny8/NTZhaSJPGpz36Kd7v+xZrQw5xOmlzpue8GRmYfbu0SRZGCgjrkTpW8RAJPdxNlpfPGTa56enq4/23t/X7w4zrNPjWhvePQBAOJJhIJfIluNptMWI1Cqr/TDYfDkXr3giCQV5FHj7WH1TtW0yi78dtzWCiWUzvgnuGgrx8tOXZedRg4MpYOgZGt4J26qvbRPbn8+KNezvrsQehZUYeSXP2rZynf/OeLHHpaDvMhdSieifc9XoxpJu/du5fCwsLUv/djZhCJBFH6SG1dtZYnKhWocxZjrNKFC866gBfMuZx21w1ccpLC+nAOwhFpY8fJnFZkWaa8YCHH7Q2DABsTCt3d3RMiV05fgFsNHtqCgxeDscBms1FbW0vJBSWYa8xsb9/OwtKFKIpCe3t7Rhy2oRCLxXC3utly2RaK5hfhelQLwzDdnoI6JElCFEWKiku480Qz8RyJD7a9Su1BnwI0tVI2yNWOth38O9eBkFD5U4VmtDtRVTGkA4nOMdTwffcujN2ZufCmEqqqEu1TLYVVE7r8ZqJzWRAEDKLEgX80sqfVwx8eEbIiudKlUp9q7ua+RIgXTacC6fHudDozbFjPPLaOt4JF1KsqH259gwMXHYuqqpRJO6nNFVjQL6egyWQaUYpitOTy5q5GLJLAizndUDq+nKCKorCzcydzvj+HZHcSo9GIyWTiJE8OPwlt4c2u8lS9sUL3wpzviXOm2kVzQEt9MxNrsP579G90vv0IPC8/RFlPE/cdWcyHhbl80Xx6Brkazt6qf5vlai0nbnsD2e+Ek7XriqJkRSquv+vt7T7WNSY4q0AbD/pc1KGPr/a+FDhmY9oDPxaLzXqBAozRoP2cc85JqXX++Mc/UlhYSHV19ZB/+zF1aGxs5bXLt7P7m7uZU6vFSprt9lagTZyxGlqffPLJfPu2e/nxMyoW+3Gp65Od2EajEWdpLUpC20BDnfUEg8FxnVp1dVHIJ6C+68PVnFZpjGdxtVqtmEwm8lbkYV9s58P6dMaD7u7uIePI9UcsFiNc/x6fmWfgyLxMkf9MQSd215SVcEplOR940jkkJ2vUnkgkiMfjdHW46fhHB9G3FCSjNu4nK6mTJImKgmVcEAhyTDwds2yqDWfD4TBNyQ6ecNjY7kh/t8ls0pIk0Ss6CQkCvqA/K+RK/3YlRk39JBdpkidjv2TF/Q8oc+afzlldIX7o9pB4408AtDRvYeelZVTcvZDqynTQ3eFUgtBnvyQI+KPaFhX1aQRuPERIURTaundgrbPimNOX59RkwmIqIiepYk1q82w8gTJ1yVl+b5DjwmEqo9pvmClJSv9EzqfVHcwdc5JcuChJ93NdhD4Iccz8k1PlBoNh1DVClmUKCk/ivh+18fhz6Xmbrfmgf7/w+WEW/XIRSqH2/4HjPhXzqkSg5PwSuou7B7Ux2zGmmbx161Z6e3vJy8vjtttu4/LLL98nNvWPGyoqKvj3v//N5s2bUyx/X/kOVqt1zJvssccey+rVqzMWrMlIKKAv27rRxLsJIwm7SKBjC7bSeXi93jEbkusL63udMg89HubCCw9iWb/2xwpJkjAajZzXk2SF6CUeXJ9R3tLSwrx584ZdsGOxGMWed3j001Ze8KQXmpnMLWmxWAiFQjiiJiRVJRLrSJVN1qhdX9i9zV66nu5i3pHptE+THRdGoxF7+SKo1/JOtkQCGMyOKV/Ag8EgWy09/LfAxaEJzeRKEIRJqV4kScL6VStLSpawPbA9K2rBaDRKqDfIshwVEHBUHzCon/n5+emsFILAyeIqVvmfZK+4BXeol927X0S0q0gJFbuzPHXfSORKT0bdE5coQSHeo4XDGY9aMBaLUe1u5j6hi/qANj9NJhPYiyAIFtLrkaIoYyJI+vPf7TKzeXOUqsPn4mJmJFeghWTQQwUphUvojsnkmxSW1fcgyYdgl9OSqqFS3gyE0WhMSc7b29tT9k3Zmg+6zZTZCYpJpDxH85IduH7q33+RtZj6bX7KQmJGG/sCxmxz9eUvf5mjjz4aVVX56U9/Oqx48eabb85qB/cjDavVyvHHH58REmJfEI/C+Ps5cKGbrIQi5X1SWUCjVeYS/xaq+RRer5eioqIxqdP0Sd0abcVYaiSvcOypbwbCbrezOFLGOb1t1Ie2EFQTIGi/OR6P09raOmyk/2g0ynp7Fw05ORjihehKxJkkV/qzjw7WcH/4DT7ypm079DQ4E1VZpjwFO9/jGyuNmOqGdt+eCGRZJre4ki0JkYBNoqdpPaXzjp3ycAyBQICSUIzjesPYo9oGM9HUNzpkWaZYVulAQIrsyYrkKhwOs2H3K9xbXcLScIxPFdUNSkNls9mQJCkt1Vl1Gb7Hn6Q2V+Dt539FWW8zb1ubeS6YD0ek2x7tYCiKIn/JyaXJkaA60cZcxu8taO3xcoIc5k2fJjmXJImOkgOp/MdTmBwOnupXdyzSdf35r8UVtrRLXJuziEOZOcmVyWRClmVtbRIMrLPOZae9hfO/kUOxO5O8jmRvpUOWZYqLizFYDeRVCHR0NlJSXJ01yVU8Hifs7+L1tla6JJHO4+amnjtUXw7OKeVakx93QkWPPvmxIlcPP/wwt9xyC8888wyCIPDcc88NuZkIgrCfXE0zZiKu0UQwWQnbZCUUus1WcSiJTYxBSItpFI/HCQQCY7K90hfWjsWtzD9xPhF3+uQ73k3earXiOPpSvO+8T40twrvvPYr1sC+kyv1+Pzk5ORlifx2xWIz3XSo77bl8Rk2rBWdyLOjPdpQdhNzxBtXmILrsSg8dMdFvqBOdUnkbl55m4bWw9v/JxLjSIcsyBoOB68sKabAa+WrXB5TOO3ZK1YKJRIJwOMyx3hCHJT38PTx543zQxvh1TSGOCXTz30jFpMmVqqrEYjGaPBvYlGNCjcOnDNKg7ygIAnl5eXR1aRHYBaON91lMwrqXtck3+FSngNmiYjZUZfR1tN8riiL/FQvoLejF35bk04ydXOleaWLEAzKERTvOvjZthQXkfqqYZCyZMtQe64atPz90WIjas2pT0viZIld6Imc9C4m37jB+GXuV0nicHzrmZNQdzd4K0tHbV907ny6TREPDc5QUX55VtWCwbRcOVUUNKoScWoDYofiEJlVeANugwCqwp8eLNSdvnyFXY1qZFixYwGOPPcZ7772Hqqq8/PLLrF+/ftDfunXrRm9sP7IGo9G4T3hNgNbXbHh2TRS6t+H5ewz8vbWdRd1p+5pUrJ5RoE/qJbZe7Ikky8zJVNvj3eRtNhvV85fxz65KnrFZ+W3vP0kmMxeNlpaWQQtJMpkkEY9zRjDI2YEg1fmaYtJgMMyoY0Mq1tXCo0iqKoUWFcXXmiqfjN2VTq7+ONfAyppKthXnApMn3JAeVwUhldqYQjygUUJdfTEV6O3Vxl5KLWXRJKCT/X6SJGFUrdhUFTE28RRPOvT3Xt3u576OLk5u19ob6r3n5eVl/D951MV8t6iA10qt5BdpBxlKlqXKR1IJ6pAkiaLuItr+0oaxTXum7i02GvR50yn7WGcy4bWkDc/rSurofr0b9/NugqFgRv3RoL9Tiz+K2h6lxDK54K/ZQP+D4cIFn6EmppAAjIs+kbo+1vVXr5MXSZKfSBD0a4bk2ZLkxmIxIl31AHRF0nvXcJIrc24JYUUlKoCvZWuqjX0B4z72JZPJjMCO+zFz2FfsrUAjIKN5wY2EbGykRqORTrGEF3bHaUgHEScYDI5pcdVPrf/b1Mlbjc0sdmg50iaizpFlGUmSsJ1yDXfm5/F2jonV6+7NqJNMJmlpacnY5BVFIeZv5yvhIHe4u5lbq3mNzpSnoA5RFJEkidzCMn4hO7iqqIAPdqST+GaDXMUk7fcV5WUaVU8GqaTeHxQh37ubnpbSVNlEk3uPhmBQ29DfbDPy980KMXt5Rl8mCkmSUCSNtEhKcNKSK/29/3eXgy/c0cnurpXD9tNoNGYQprKaI1jVFeOCLj/3FefzYG4O1vlpneBYyJUoilQqlXhe9KC0pOfnWL6LPp9fKE3ypbJiNudr5F+SJArzCvlel59fywHC7Xsy6o8G/dlPhjvYFO7gUJM51deZgtVqTR3uBKOTH9Vew88qrkDMSTuYjUUlCOlv+6WtKq83trC4S7Ol00NyTBaKorA3uJ1f5ebwujXdp6HIqSzLIAh8qbyEQ2qq2OJ5P9XGvoAx0e2nn36a0047DVmWefrpwakN+uOss87KSsf2Y3TsK/ZWOhwOB06nE7/fP3rlftCNGycLo9HIZvNhXPTI65x6qrW/+UfK9mokKIpCPBah0KoZ99qKxxedfSDsdjtLlqzkoL8KHFDg49iuF1EOvjZlewXaRuz1esnP107IsVgM/x5NQtwcAEe+Zow/G9TDFouFQCDA35L5+G1aTrnD+8omSq501VQk6Oe/LS0ERQObj9YibmaTXHXZF/OPrW9iPCCYKlMUZUrihuneoA8caEMxVPCVfBcHkh3JVX2OmZ/nOAkmIyybJLnSv1lTUzNtQRVzmRZZb7j3npeXl5LKAazMu5Kf/uYGYl+fwx5J5pcV6VRWYzkYSpLEsXkdXHOVne2xD1PX4/H4qN8+laYqHqdSgVyjFkpIFEVEUeRTCyTK7SrPde2FuQeOWRoSj8dRFAVX39JryS9PtTtTEAQBp9OJ16tJCNWSIwfVGYtKEDQJuCiKxEwFQAfmiKbqzUZgXV1V2yC08VxeLock4xzWVzZUu/o1Ma4dqrwhLZCoHkR5tgcSHdObOvvss1NBRM8+++xh681kENH/j9iXJFc6SktLCQQC4zpVDzSgnShkWUYoFai5voZWqTWjrLu7m8LCwhGfoygKwY56DIJAIqliK65OtTsRWK1WfD4fn1h6PavWXwkIbNr+Nq6FmbnA2trasNvtGI1GYrEYvo6NBASB1rARfQTMpDG7DpPJRCAQINddzdbVb7Fk/hI4QSubqMegrp7z1X+EQRAQIkkchZN77/2ht1FSotl+9E/aHovFsj7HYrFY+uSdCyaLiVxrLpAdctVsF3kqz8kBqpI1tWB7TjuWORbKKjXJ83DvPScnB4PBkJrbS1cej/JgIUWvdFBW4sKwUiMgBoNhTONVFEUsVhMWs0zMmybnY/ld+ju+vsVNdUDlvxUXpp4tSRJdioxLUAj5mjLqj4Z4PE6PpwNbX/BQU35Zqq8zCYfDkSJXQ2EskkIdsiyTsJcBm3Ek021ONrCuHkC0LBDi05YgQm9uxjOH6gfAZxuSHOds4tXewlTZZGw4pwtjUgv2VwUmk8lh//YTq+nFbNhQxwtJksatHszWJDIajeTk5mBfbEctiUM/MXc8Hk+pa4aDoijs6HiPK4oL+V9HLqKk9Wuim7y+4M1fdjA3b1tAzc8C3PvIc4PqqapKc3NzSorzqNrNkTWV/KA47U04GyRXeh8Oyj2I7pe6admQTrirKMqE1FT6Bh9p3QZAS0hO5XLLxrjQgxfmFEscdlMNhlPSATGnwrZDH2NqMo7np/Xs+cEeqnI1Q+9skKtSCvhMT4AVvvCk1+NwOExP2I/tczbqbq6jrFiz7RluvBsMhoxkzoIgcME5l/DKn7ooSZ6Zuj7WRPOiKNLglDilspwH56UlL2NVC6qqyj1vx/jxm1Hkovkp9b0oitxXnc+hNZW8L+xKtTkWtZeiKOzt2shny4q5vsAFxnQC8ZnESGEWbDbbuGxCjUYjgaISbixw8fua9LoyWXWcfv8Kb4Bb3d0cGEqHwBlWLQgYycOZVDFG9q1YV9OXaXI/sgqz2TytiUKzCafTOa6TVLbIlSzLLCpawJfqPTzV047q2ZVRPpphezwep723ntVWC+ss6UVnoptif4eEoz93LUqRiQ+rP+TpnYNV76FQCI/HQywWoy3cl7DZkCaps4Fo6+Rq4ZxK7jrBxPfmbAY1vcFPRDWok6t1sQ3cUpDPa/bcVFm2xoUkSVTk5xCaa8dTIpFIaqRqKhZwnVwluhtp/7xE5/kiLqcWYX+ykjhRFJljrOYmj5fTvOOTDg9EMplEURRaWzZySDjCgmiMihIt1vdI432gYfvZZ5/Nyy+/zBe+kPaEHas0UBRFnLYSZFXFSOZBaDQoikJvby/3vxXmuy9FcZTWpfotSRLGvhQ4ver4AokmEgk8wUY2m0xsk9NEf6azZBgMhmHtqsaqEtQhyzLmwlr+7bCx1mlGTWrve7KHDf27/eRDB0f/vpdW58HA4OjsOvR3utl0CEc81Mvvd6Q9pz+W5Orqq6/m/vvvH3T95z//Od/85jez0af9GAP2RZWgDkEQKC8vH7OqL5uSq3lVCziiOcQcJY7/w39nlAcCgWEnrS6dLfOGua3Lw7Ed6XoT3RQFQUiRzGXLlrH0U0txHOTg2ba/oyYG96O9vZ1QKET8uThbLt/CwVJ6cZrpxR3S36l67gK+eKSZ3EUS3W0fpconQ65eVRP8w2HnFWNFqixb9lBGo5GKyhV8r8vDzzu6iPd5OWY71pWqqilypae+8UXVlO3kZL+hwWAgXHQgVfcGOOMJcVKSK/23y00N/KG9k/t2dCLI5lFV9BaLZRDRLyoqytg8x3qwEkWRGudCPqhv4tGGtpRkaSzkKhaLsbVjK3O+P4fqy6qxWCxpGx5R5AS3nTcbmjitOTOQ6EjQCVihX+Hn7Z18vlX7lpMN/potDBdOZrzkymg0Ul11CCds83DE2x2EAtqhc7LkSn+/W9r9vNmUwFysxbgabtzrpCtWUsGuA/LYXvExl1w9+eSTHHXUUYOuH3nkkTzxxBNZ6dR+jI59zZh9IIxG45gjo2drE9VjXdULmhrG3PbuoDrD2S3ok7nXI5J4x0dOZ35GuxNFfzXK11Z+jUObe/iztwk2Dj2XEvE4Z+Xv4rw6A/PLNdujmfYU1GEwGLQ0Q7n5fL24iEtLi3m/4b+pcr/fP26Po5Sn4KYknU91UiguBSafa7I/ZFnG6czniJYgR4cjhFp2as/MslowHA6npEntvj087rDxujmtIsuGainHVUJTj0pHsHdSkiv9vce7tHfRoWiEaCxzUXe+GA5jXbtEUcRaUIEAOEwCkV5NYjtWyZWe+ianLpO8SpKEUS7QUuAkMh0YRkIqDEPQz6pwhAV+bSzPBmIFQ3sEiqI4bpMBWZbJc7r4/S+C/Pw3HtrdmnRvsocNXVVr/Y6VRb9chDF/dLMKWZaxuWyUnF9CckV6PH8syZXH4xkysGFOTg5ut3uIO/Yjm9AX4PGo1WYrXC7XmCZ+tiRXeqyrSMVK1ljMvFoUQE1mnu67u7uHJAD6gr66zcQFT4RZox6cKpsMuXI4HKnFZeWKlRy8SWaOEqdgy+8hOXgTSQTaufEwhb9+2kJFhSbFmQ32Vjr0jdMVFKhSFBK+dMLV3t7eMccU06Ev6F3vddH5VCfLXJNP2DwQujSmI6K1Ge3UCMVY7XDGiv42fU2hbdxe4OLRklxgeNXIeGHKMbH4t4upe6CO3kjvhPuvSxmlnkYAfAaNMI3lvefm5g5LfC0Wy5h/pyRJmJxFJJJ9+UA9aW+xkZBIJEgmk9S62/hZRxff8gdS7UFf6BR7n5etmna0GG3D1p+7p0fm1teirO6ZeU/B/hBFcdC+MJaUNwOhr0elpVpYktZWTZKbDcmV29uAQTYgWkWqC0e3NZRlmbkFVZRs9XPAHh9xJZaVvkwHxj2b586dy/PPPz/o+nPPPcecOXOGuGM/sgmz2czChQtnvafEWKCrB0dDNn+r0Wik5JAz+GZRAX8qyKGp5Y2M8uEM2/WFty3ZhqnURH5R+nQ+GcmaIAi4XK7U/3NOvI6u3iSlxhDCxr8Pqr9t76vcVJDPr2U7eYWah9tsIle6Suj45nyebW5jVUdnRnl7e/uY1YOJRELzMEom+fq8Vq5eaaSqVPMYyja5AmgQ7bxtNtHauztVls0Tcv+E3PmBNk7oDVHcdx7Nllq31FWCQdaWdbd774Rjdemk9rHqAP9TWswOl5YJYCzvXRTFYVVU4zFnEEURwSBymymXi+357PZqpHe0b6KX23q6+UQozFyfmGoP+rwqC5dTucHEFyM5g+4bDvq7XKdE+WmHxFpxXqq92YKB732s8a36I+VBW11MyXwLLW5NtR+PxyclDVUUBaGjmbfrm3hkVwu5OXkZzxsKRqOR8sJKnjf6eNQeJNixF9g3yNW4R8U111zDlVdeSVdXF5/4hBYB9uWXX+buu+/mvvvuy3b/9mMIzKbJPFlYLBYKCgqGlXpm255BsyeYy4qNYcpsKiHva1B5fEad7u7uQYuSvrD6juxm3hnzSPZMPDr7QOTm5tLR0YGqqqxYeTR/fKkI80qFV4P/4ObEpxHFtA3LHu8m/uWwsyBp5Ji+E+lsMGbXkSJ6hYshuYViwUOgX7mqqjQ1NVFXVzfqe9M3+M72bZx+pJkyRWRHmUbGp4JcvV7m4PVSB0d3d3BQX1m2XL71lDc6jvS2cmG4h/s7D8vow2Rhtdj45+5mSkWVt8x+PB5PKszEeKD3tdku4DOaWJVTMa5+5uXlDRnPbjwSd4PBgCAIPGlwYCg0UBLt5TBGD8WgkyQx7AE7hA0O8kivmwaDAZvLRe6nilHj6piTE+vPbSxupPa7tYSbtXc0m9Zjh8NBW1va43W89laQDoq8+Pgeusvq6PasBa4EtHc70fUmFosR7arHpqqYe1T0tz3S+5MkCclopjMkUGqH3rad5FYsmLIAv9nEuHeFiy++mLvvvpuHHnqI448/nuOPP55HHnmEBx98kEsvvXQq+rgfH3MUFRUNu2gbjcas2hPpG+Uxe/K4zd1NXevmQXWGMmzX/z/PFMWRSLDEok2dbNj+SJKUYXvlOO5KHnPY2WGWWbfpFxl1Kz3dXOn1sbQr/czZJLnS+2KpOQSACksMIZFpqxGNRuno6Bh070Do5OrD5lc5t6KUzxeXIFu0zSKbwT31tpzJXGpjCs5YWrKWrRNy/+CaQiJGuVGzH5KqtPeUrQ1aFEUsIRWbqqIEu/B4POPeiBKJREolemd9B3d3dFFTovVzrO/dZrMNWXe8jjgGgwF5k0zrI63IfjnVv5HUnSkps+zjA5MJn0WT5vR/x7XFtXS/3k3Xf7oIRULA6N9af4+WUBS1PUKRpLU7W9SCoK1v+hw0mUwTGleCIGh2iOSSn0hgSU5+PugBROO+ZgC88fSaNZrNFUBXzEhUgF6PFlF/Xwj9NKEj99e+9jWam5vp6Oigp6eHPXv28MUvfjHbfduP/ycwGAzDqgezrf7UJ6tSvYoH34/xu3VDLxY+ny/j/4qioCaT/KWlnbWNLVQXLslob7Lorxo88sgTWb5R4d6OLk7b8lyG7dVcfxeX+XpYFNDizukRlWcLdPul8vkr+H5OLmdXlLCp8dVB9TweT4aabCjo5CrU04QjkSQvklZJZHNc6BtQGYdjvHc3TS+lDa6zRa76q5oj0QA/eTfJ3zcrVCzWYthn02kjENfGQzzgRlXVVFLfsUJ/7x6Ph1V3dnPJnW4K67R8BmN973oy5/7QUz6NB6Io4mp30f1SN0lv+vuPtLHq5Or5siQXlRWzLd+SaktHcUEx3+v08hs5QLSrMeO+4aCTqzu8rWwKd3JOH8GbTfMP0qrBiagEdciyzIHCEl5vbOGq9sl76SWTSVRVZbvawIO5OXxkHzn1Tf9+APy6Ip9DaqpYK2ybdF+mCxMiV/F4nJdeeol//OMfqRNEa2vrqEEY92M/hoPdbs+Q3ujINrnS26s9/EyueDbCb9c10+hpHFRvoGG7oiiEu1sx9eW3c5RMLvXNQJjN5tSpXhAEDlpwFUs7e+n09hJs3ZGqly/4AFDzalP3zQZPQR2CIGAymbDZ7TzlNVNvMvK2p2XIus3NzSNKVfRN/qC2IGsbm7lgb3q5yqbkShRFDAYDlrJFPLk1ztpdvlRZthbw/kTy+cY1/PX8aq4vLKK6pgbInuRKkiRez7Hx81wnTYomJfB4POM65evvvampCRVI2IqRTeMPFzFwPk/ECUeSJC6d383uq+0cGFmbuj7SuEmlvlEUqhQFZ1/qm/59l2WZsxfKfGqhTLRzT6rNkSRi+jMdoka4RXvBoHZnA3SHs8mQK6PRiKVkPgDFZiUVcHmihw39m2wz+/llXi5b8tISzLGQKzmprdvBfkYGHzty1dDQwLJly/jUpz7F17/+dbq6tNxDP/nJT7juuuuy3sH9+P+DkpKSQafAbOd209srKipiwVcXsODeBfx1218H1dODEGb8v0MzdO4Oq5hsg1UNk0V/6dXKo4/notXlHPhggN88/jxJNYmaTBLKSRASBIylWp632aQS1KH3ybHDRf3d9Uh7hn5HiUQiFXl+KOibvCWiqRAVUzp0R7bHhSRJGSlw9D5lI9ZVRsobYHPHZgRJIMeSk2FknQ1IksSbeVZ+neekSdDsGJPJ5LikV7rDwbqOdThXOilfkvaKG2+k7/6EaqLkymo1YC6UiZCWoIxErnQCcGOLm2eb25hn0+ZK/7VFkiS8MZmwIBD0NqSuj7Rh68/MkTWiKuUUD2p3NsBkMrFo0aJJeZTLsoyzchFJVcUigRrUHFMmS64W94T5dE+QsnhuxrOGgz4vjvS7WNPQxPn1mWvybMa4ydU3vvENDjnkELxeb0a8knPOOYeXX345q53bj/9fGCo1zlSpBQFq7VWQVIn4tw5ZVw8boNsLbPB+wNeKC/ldTu6Q7U0WOTk5qcVEEATO/MKV2A908ObcN3m+6Xk8YQ9fqCllZVUFtmpNLTmbjNl16ORqkX0RwY1BmnY0DVs3GAwOGZ5BT/UDkKv6AEg6067b2ZbW6XHXVl5TyYE/qGRny1tAdhbwgRL9RRt6cH9vO/O981PXskmu5gcEPtMToDiY3gjdbveYpVc6ueo0vEnl1yqZd5SmjpvIXOwf82oigY9FUeS9QhOnVJbzbHma6I5FcnXP23F+tCaKXDQv1Vb/dn9Wnc9hNZW8Q1oyPFK78XicaCLKdQuKuby4EENu0aB2Zwsm2ydZlskvLOE2ex5fLilie9ObwMQPG/o3OcHXw62ebuYbNMn7aA5BunG9yVqOM6ni/DhLrtasWcNNN900aKJVV1fT0jK0+H8/9mOsyMnJyfBwyTa50mNdAXy6dBlrmpr5Y89OhOTgidrT00M8Hk9tSq3RFtZYLWy3pAlNNiVXgiBkbEarVq2iYnkFxjIjLzY8yp72ncQDcZTuOKWlWgDR2Sy5OqCuhL+fZ+E7hYNtrvpjqPAMOrFKqkl+Nt/Ora58kkVaqJepIJSyLGMymSiuMxMsMNHW9h4wefdzGECuknG+XbSGtkssHFdTlbqcTXJ1iNfCTR4v8/1pcpVMJkdM7Nsf+reoDvdwUCTC8j5v1YnMRYfDkYrhNZH7RVHEYrBjTKqIpMnhcCRIVVVNhR8O87O1vdzwchRHyZzUJq1DkiRkPQVOsid1fSTJjKIotHub2G4x8Y7FTE5BdaqPHzcYjUYMBgMfWUy8bzHT2L0F0N7PRGKn6UToay+bOPr3vYQKVwBjG/eyLNNTeDBHPNTLVa+m5/7HjlwNZ6Xf3Nw8KR3vfuwHaASjrKwstRBmW/3Tv80Fh51FNJDAKkFs79tD1vV6vamFfKE3xu1dHg52Zy7S2UR/ciUIAhcf+GXOb+jmya56Kja/wrartpF4KJE67c1GyZXep4o5C1lwkI2dNRLB4GC7Nh16eIb+JEY/IXeEO1jnMPOk1YazZiWQfcIN6TFxan2YB9s7qfRkR/3QP+UNgLGnAbOo0hNVKV18ROp6tsaRwWDgjeTBVN4b4JHmioyyrq6uUYmiHlsM4IL2bv7Y1sliaSEwsbloMBgoLi7G5XJNSNooiiJLhRreb2ji2t1pcjgcudL7vrF9I3NunkPlJZXYbLZBBEgURY7vtLK2vokzmtLSmJG+dSKRQPD5+Xl7J3d0upEdBam2Pm7Qv3XNdgPHrW1H9Gp7+1hzMA6Eoigk1SQb2ny82ZQgpy9P5VjGlCzL2Etr2XVAHq0rVZS+g/Bsj3U1bnJ10kknZcSzEgSBYDDILbfcwumnn57Nvu3H/1MYjUbKysqwWCxTsnDpm39evov33ZqqIrT5uSHrdnd3p1PfdMrE3/Fh8U+t7U//DAgnn3AKhnchJ6lycuw5blll4hNzNdssURRnnTEtaL/BYDBQNXcRN+Tlc0dBPtsaXxnxnoHhGXRyFXQHaf5NM51PdlFQUglMLeEu85k5OhzB4U/3ZTLkqn/KG4B3d/+bH7jyeEQxMadubup6Nse5mFNCc49KVyBTHZlIJEaVXvWXIJZZtG9gKp04uQLNlnCsqa4GQhRFZEeRlgJHSn+H4TZ4fcNt7d6BdY6V3DnWDGm1Di0FjguHqmIZQwoc3dsNXxerwhGO8IRBSIdj+bghFVi3eRE//42bXa1pCflESI2iKLT2tFJ9TzULf76QgoKCjOeM1peSohKKzi4i59gc2nraJtyP6cS4ydW9997L66+/zuLFi4lEIlx44YXU1NTQ0tLCj3/846no4378P0ReXh51dXVT0nb/Cb0zdy7fLnRxT+6uIesqipIKy/B8o5ELngizyXxYqnwqFtb+hu0GgwH7qitpDWgb9PXHmzmmWnvmbJRagXbgMpvNmM1mqj0KR4XCqB27R72vf3iGVDiAVg++tT5s22wpad1USq7CJu3dmyLpyPKTWcQH2lt9FNjE33IcvO3MTT0z2zZk/iI/i3+7mM5jOweVjSa90t972NtBUZ+JVG6tpsKZiawQkiRhdGqOBrnG0XPL6dfnuju4v6OLa/ve/1DkSrVpXoRjSYGjS8q6gglueS3CX3altTQfR8mVIAiIopiyge0fmHQih41YLEZbXxJ3q5oObjpWtaDD4aBycw9LN3oIt2lR2rOdnirbGDe5Kisr48MPP+S6667jsssuY8WKFfzoRz9i/fr1FBUVTUUf92M/sor+5MpWvYoXbVZ22ETc4aFtBvVI0x1iB6YyE3kFWvwefQHKNqxWa4Yt1fEnn879exwsq61iZU0l3YVazq/ZaG+lQ+/bEbuN/Kqji6UdrWO6Tw/PkPIUbF7NPaeYOG95ejObik1eX+RDjmLeMZvYYUuTosmQq4GxvA73eviyr4cSf3YSfw+FcrMBg2wg1zG43/F4fFAMt/7QJVdr6p9mVVU538nNx5qvkZupkBiOBlEUMeWXc709l2sL8wlER07erG/89h4vx4fC1PqGli6JokhT4QoqN5i4KJZOGTPct9aftz3k5+5OmUd6NNIhCMKsCoWSTRiNRopKCimZbyFmSR8+xzsfdIegik4Pb9c3cffernGZfeh17kv28ld7L7bOtHfnbI7UPqFZbbFYuPjii7n44ouz3Z/92I8pR39SsvjQM7ji1T9wiJggbt0Ei4bPdRg5I8y8c+dhjGmb+1SqA1wuV8pBRBRFnId9FUviceKCgFy0dNDvmG3Q+xZy1AJt5MZaGYufkR6eQSdXkfgmzjrGxqZ+QpipVAt6XflcUlBMvpLgkL6yiaoFB6a8QU1yWtSN1ZvkAeuZg56dLRxiKeaLe1vw+VWGUp51dnaSl5c3JCnQyVW7fxfdDpHuZGZsqOmGKIrYimp4xm5DtIi09bTjKMwZlVyJYTdYIWRwkM9g6ZIkSdjy87UUOAmVpJrEIBhGlVxtM2yj9ju1GHYaUv37uELzoI1QcGMdHQktiLJgMIybXOkq1YS/BZuqIoXS42iskivQo7r3kvCm7TcVRZmRcTkWTCiI6Pbt27nyyis54YQTOPHEE7nyyivZtm3b6Dfux37MAvQnJTlOJyW74aBoFGXbS8PeoyQValFwJBIssGshSKZyUjudzoyF+7TTzkZ6KEHi520sW3oCMHvVgpB+x1LZcgBKjAGSybGdMoPBYEp19WR5mLMrythSNHWSHkjHcCpyLaYmprBAiZHsM5wNh8MTUj/0j5MGIAeasEpJwopK0aIjU9ez/XsKKpdQmkhQZ0kQ9g1OMzSS9EonV8tbEjzS2MaqPm3QTGUCEEURWZbxPeuj9ZFW4kFtDA2XAkcnR82yj/fNJnzmoePRGQwGqgqqtBQ4z3QRi/d5pyaTQ6pNdRsvKRRCbY+Qq44/qOq+BlmWqSg9mPxEgjpFQYlqsdLGG45B/yZCoB2AoJD2Bh/L+9PrPTS9SAAATTNJREFUBAQHEUEgFEpLwWezx+C4ydUTTzzB0qVL+eCDDzjggANYvnw569atY9myZTz++ONT0cf92I+swmAwZBCsD4xHcPjverl33fDqJiHSy9OtWuqbwkka+I61j/09ByVJ4mf3/Zlf/+LZVOTr2Uyu9L655h3KRUWFrKorp6Vn6HhiI8GRiGNPJnFZNbd3Pb3OVECSJMoqDsB472423NmImkxHpW5paRk3wRpob7XR28lnXo9z8+sx5s5fmPHcbKJi6VHs9hswigIdbz46ZJ3Ozs5Bv6d/2Il/7c7hoFs8vBs4BpgZqRWkJUPCOoHul7pRerTNVFXVIUmQLlV5tizJl0uL2ZU/NAkSBIGigiK+19HNb4wBol3NqbKhNmxdcvVFdxubwp1cEw1l9O/jCFmWKa+Yy+Nbm3i0rQO1Q7N1Gq/kSn+f661dPJibwx5HWg07HrXgGyUODq2p5KnitFPGx4pcXX/99dxwww289dZb3HPPPdxzzz2sXbuWG2+8ke985ztT0cf92I+so3/04rKDTuEjSWa9ZROtkaFtg4Jtms1BT1TF4dJsUKb61NqfXIGmjtcNQWerp6AOvX/VtXWsblWJqQL1ft/4GlFVHmrtYG1DM1VFBwNTa1QtyzIFhcU8vRPeaVbocqeDm/p8vlQ2irFioL3Vky0vsOWiOTy7bE4GMc72d5RlmXelOdydl8vfjW8NWae/o4aO/p6CTU1NJFUoqtBii82EMTtohwxBEPjFSQl2X20np/O9VNlQqkF9sy2KKVQrCk7j8IE+TSYT5y428qmFMpG+FDj92+gP/VnmhCaNjJs0j97ZPAcnC6PRiCzLtPRq7y7UpgVbHa8huf4+1zkVfpmXS2vu+CRX+reziLkAhMX0d/9Ykav29vYhkzR//vOfp729PSud2o/9mGr0zy6wYsUKSs4twXqKlZcbhs4yEOmqB6AzbJjSGFz9IctyKgnrQMxmeysdZrMZWZYR14vsvHEnDB/qakjEfG3YjZqUIq/mAGBqpXVGoxFRFFOOOQPXs87OzhGNwftjYMobALfPTTKapFQqzbie7Q1akiSEupP4o9PB+nyRzuDQjhpdXV0Zm6Su7lGSCl21XeQcmkN5pWaDOFPkCrTNNS9HxFQoEwilf8vAcAz9YzB+v9nNM81t1Nq0KPhDvWNJkvBGJUJjSIGjkytLn2ehaslP9e3jCn19cyvaWhl3pwnoeKRX+vs80q+lvikyaIfT0aKz69BDaSyQ57KmoYkf7kofcmZzOIZxk6vjjjuO1atXD7q+Zs0ajjnmmKx0aj/2Y6rRPxWH1WplYdDKnJYgpbvfH7L+O6EPuby4kH/mpmNQTceptX9Yhv7YV8gVwHxhPrGOGJtf/yfGnoZR7krDX6+5brcFBWxObTObSkKrt73sU7kc/tN5vO/9+6A6zc3Ng2yphsKgJPaqyhkftZF753YOdawY8rnZgiRJLFx5AV/o9HNPRxfh9UPbEsZiMXp60tHJdclVW6AeyykW5l5WQXVZ6ZT0cTwQRZHHyx2cWlnOWktafTdQctWfFN3zToK71kSRC7XUN8ORq59V5bOyppK1yS1DtjPwWQ8utHJZcSFehzXVt48r9G++tlBLgfOiMU2uxmN3pb/Pz/b4udXTTVWOlutxPCFIjEYjNlcdzqRKkSn9fWYzuRr37nDWWWfxne98hw8++IDDDz8cgLfffpvHH3+c2267jaeffjqj7n7sx2yELMuIopg66X7aWsUlsbXs9kUJD1G/Ve3iTasF2SxmtDHVsFqtmEymQYvZbLa30qGTq8997nOUtb3Az+a/zc53I8Q+cR9Gw+iSkFf9b/DXkkIWJ2Oc2HdtqtWCAHNL4PUCE2Hf0DkRGxoaqKurG/EbDCRXcqidb85r4oo5Vv4+d1FG2VRIriTZyNIGG8ssLTzVsI7qY740ZN3Ozk5ycnIQBCFFrkItOzgrECSWgMJiLeTATJIrSZIwJ2SMSRU1mVZdDkeuYrEY972pqWTX3KapNYciQVoKHO16b2LknHX6ta0OIzGDgeONhak2Pq7QnTz8FjvvW8KsiKVXxqamJoqKinC5XKNKn/R3d9KjCXIMIW68X8uLOp53J8sypvIlHP79XtpDAv+6MIEoirNaLTjukXHFFVcA8Mtf/pJf/vKXQ5aBJsqbSJj8/diP6YAgCFit1pRdjHXJqdCyljprL1siPpLm3Iz6h7pjnKh4aPOlJUnTsbAKgoDL5aK1NdMWbF8gV3ofDzjgAJ4tPIhHnE38wunhcw2PcFLt6GFc3k0otDgsNETyU+RqKjd5/XvODbr4bPt2gj7nkPWSyST19fXU1dUNOQYGprwBUBo1ieimziTzzlw65HOzBd1OaVftFznj29+jqno3z3xt6LrRaJRAIIDD4UiRK3tbCz/0drPBIyGcMHWBW8cKURQ5xuPgf2Obedlbmbo+HLla376eOTfPIdoYJScnJ/U+hmp3VYeFH0X2sqanblA7/aF7J97R4kYxi9hqalJtfJwhSRKFyfkct/a/GBNl8AntuqqqdHR04PV6KSsry8gHOxCKohAIBdji6SUZSZJfrKVlGs+YkmWZ/KIydi3MxVhuZGvHVpaWLU15d45FvTjdmFBuwbH87SdW+zHb0V81uOCgo9nclaRXENi1+YlBdf2tRmJv+zDH0ov7dJ1ac3NzBy0e+4JasD8BPPvia/ioMU7YYGBz+2tjut+61Urz75rJj6Q3vumQXOWZqjg6HGGe0jNsXUVRaGhoGNJjbWDKG4C/dD3HZcWFPGfKzXCm0JMaZxuSJHHo0Z/AmGvCX+XnhR0vDFu3o6MDRVFS9leqW3Pe6EqkA7fOtORKNecjAKZkWiU7HLlq9Wipb/JqbSMG+tUkfC5sqopZSUuuBqqa9Hx6SjTC6fEInwr24nB9fJM294fRaMRZeCQ//42b/7w5WAUXi8Wor6+nsbFxxKj5H7R9wOJfLWbu7XPHFZ1dhyzLSJKE62gXrk+42OZOh36arVHaZx/dGwY//OEPOfLII7FarSlX9IFobGzkk5/8JDabjYKCAq6++upBE2Xjxo2sWrUKi8VCeXk5t99++6CP8/rrr3PwwQdjNpuZM2cOv/rVr6bqZ+3HDKI/uTKZTPzLXMTR1RX8OvraoLpP7THy2SfD1Nu10JJTFZ19KBgMBvLy8lL/F0Vxn1jUDQZDigwtXryYrj1zub+tk9+27MbSvWWUu8Gz1YNvjY/5eZpR8lS/c51AGAs0VVKBMTJSdcLhMM3NzYPWj0H2VsA2QzdrrRbc5kwbuqmSQEqShN1uZ+n/LKXiKxU83/LUsHWj0Shutzv1fzGk2TUFZU31NZ1jfSiIoggWbfzbhNHVggvcbh5o7+K68NCpb3RIkgRW7Tcak6FB7ejQBQU9Pg+3vBbhgXcVLHkl6b59jGE0Gikp0X5r/xQ4A9HT08OOHTtwu90Z80GX+PndGwEoktJSxPGQK73usi6VZRs9uDqH78tswZjJ1TvvvMNzz2Umt/3Tn/5EbW0tRUVFfPWrXx13cLHxIBaLcf755/O1rw0t304kEpxxxhn09vayZs0aHnvsMZ588kmuvfbaVJ2enh5OOukkysrKeO+993jggQf46U9/yj333JOqs3fvXk4//XSOOeYY1q9fz4033sjVV1/Nk08+OWW/bT9mBv09BgGs0kLigoBClFgyk5R3WbowlZlwFWqb43TbWvQPy7AvSK109O/rOV++lvq3AwiA9b0HRr33yspt3H2yibklmsfkVMa4Am2jFAQBa+l83jObeCXfSiTiHvGenp6ejITTMDgEA6rKdzrcfN/dTZGUaW81Vd9SJ4pnF81nbjjKyb0jOxJ0d6fDTvx4fpxPVJbR5NK8JrOd+3C8EEWRYE4e37bn8kBZWuo3kFzpB2lHj5fjwmGq/SMnVhZFkXrXgVRsNHGpmpu6rkuqBj6nwdfB3Z0yd+yxY5CMqTY+zpBlmbKyMornmKk9WKXLs2fYuqqq0t7ezs6dO1NOHzpRPbSzh7frm/hOa/rgMR5pqF73clXhUXsv8zxD20POJoyZXN16661s2LAh9f+NGzfyla98hRNPPJHvfve7/Pvf/+auu+6akk4C3HbbbXzrW99i2bJlQ5a/8MILbNmyhUceeYQVK1Zw4okncvfdd/Pb3/425RHzl7/8hUgkwsMPP8zSpUs599xzufHGG7nnnntSbPtXv/oVVVVV3HfffSxatIhLLrmEiy++mJ/+9KdT9tv2Y2YwMJho2eKz+G9DMy+0tmIO+1LXI4kIwmcE5t05D6dLs8OZbjWJyWRKidP3VXI1f/58VnMY8aRKYWADTa0vDntfT6SLwqXw6WNslJVPXzgAWZYpKK/lOwUubi500eL+aNR73G53ipwMSnkDSBE3h6thPu0PUFq7KqNsqr6lTiiOOvQC/tbSznURH+GmDaPcBXE1jttkoEuSyMmbC8ysvRVoBCZUsJTnC3N4r8hMUtVUrgMlTPr/DWGNEIcETa05kuTK7nKRd1YxHAIJNU2o+retk6stgS3UfqeWgs8WZLTxcYYsy9jtdg69tpL4F6vYVv/sqPfEYjH27t1LU1NTai4YejuwqSqGeJocj1ctCBAS++KLhQcnJZ9tGDO5+vDDDznhhBNS/3/sscdYuXIlv/3tb7nmmmu4//77+fvfB7suTxfeeustli5dmsriDXDKKacQjUb54IMPUnVWrVqVIYo/5ZRTaG1tpb6+PlXn5JNPzmj7lFNO4f333x9WpxyNRunp6cn42499A/1Vg/OWH0ZHa4Lt7gTtO9alroei3cyNxShR4tTka+qJmbBB0cMy7AvG7DoGkoezL76G32xLclZZKTe2/gF3bGjJ0Iam17iqtIhrC13kV2hqwekiVzk5OczzRzkyFCbqHltwrtbWVgKBwJBhGpIt6wHY6k4yb/HyjLKpIle6RKWwci7vdGrP6HnvsdHvU+F365v5c1MbpRWHArODXJU4S+h8qhP3E26SaOSqv3RJVdXU+twoe3nPbMJvGTr1Tf92K12VdL/ajedZD/Hk0MEp9eckgn7U9gi2UFpaNRsNqbMJ/duXBJIsiUZR/WOPZen3+1P5UeWIljonIuemyieiFlQshYQFgQi+Md87UxjzyPB6vRQXF6f+//rrr3Pqqaem/n/ooYfS1DRzorr29vaM/gHk5eVhNBpTwQCHqqP/f7Q68Xg8wy6hP+666y6cTmfqr7Kycsh6+zH70J9cybLMt7csZeEvevnvpnSgOpPXzz9b2vl3fQvOokoEQZgRcmW32yktLcXpHNqLbTZiIBGcM2cOa+NHsbM+SiLKsBHxo+4mFkRjlAbjyH0L/HRs8kajEUEQ8D4eZ90P9hIKzRnzvY2NjXg8nkHX/+ruYOUagTs2OQZ9u6mWXAE0WpeRBPyxjwapuwfC7fFy2P1+DrvVS0H1YmBmjdlB+y2uXBedT3XS8VwHSUUjV/3zAOrJgQH+VZrg4tJi9uaNHItKkiQK8l3c7OnmN7KfhDctDRlKcnWMu4tN4U4e6JNqD+eF+HGC/u1P2wmPtXawzBMY5Y6h8ZorzC9znXQ50raj4xlXut1fsyuHw2oquXv+zBL+sWDM5Kq4uJi9e9O5hdatW8cRRxyRKg8EAuOehLfeeiuCIIz49/77Qwd1HApDDXRVVTOuD6yjT8jx1umPG264Ab/fn/qbSZK5H+NDf3IFsPzQwyn5XAnPlz9Pe0Qj3OFObdx39ArIRiOqqs6IOkAPy7Av2XnoZKU/LrzkGzQ/1M7mb24muWewtx3Awo4AT7S2c97OtB3ndGzy+ndtESt5vzVJc6d3lDvSUFV1SMnVK8oaQl+opHX+3EHPmqpv2Z+I2g++gAvLirllXg4b2t8Y8T597SoqKZ1WUjsSRFHE4XCw+ss29lxtJ9y+M1WmS5X6Oy6VxBRqYgo5xrTN2FAQBAGL1cq5i2Q+uUAm3LE7VTYUuRIiPgDCwsc/gKgO/d2FTJoq1DhBddwbLokH85z0OnOBsUdn7w9Zlsl11AAQkYSUeni2Ysy/7tRTT+W73/0uq1ev5oYbbsBqtWZEZN+wYQN1dXUjtDAYV155JVu3bh3xb+nSpaM3BJSUlAxKV+H1elEUJSWJGqpOZ6c2WEarI0nSsNGyTSYTOTk5GX/7sW9ADyaqY+VhK7FUW0g6k2zwaurkWLe24XTHpIz79mN0CIIwSHpVVVXF6UefTjKSZP3f7sLs2znoPqlH81jzi+mT7nSpBYExeUiNBaqqkmhPEGmJsChveozZIdNZo3b5EZR6Y9iTSVp2Dh2tXcca9xoKTi+gbHnavGKmx7oezLK0QEIulPF59qbKdOLTnwzd2uzm3y1tVFrnpe4fqW13REuB09Ndn7o+FLmSYn4AYtL4Qwnsq9BTzyTt2nhwJHwTaudT/gDn9QQocKSDuo5X6mc0GikuXMqbDU28Ud+EgdkZgkHHmEfHD37wA84991xWrVqF3W7nj3/8Y8Zi9/vf/36QrdJoKCgooKCgYPSKY8ARRxzBD3/4Q9ra2igt1VI2vPDCC5hMJg4++OBUnRtvvJFYLJbq+wsvvEBZWRk1fUHhjjjiCP79739ntP3CCy9wyCGHzPgisx/Zx8BgogsXLuTcF4IcZ+/FFq6HUnhd3cw/iguZF09wSt99/x8W1mzBbDZnJAUGuOyyyzjA+xw3H9zMy+/cRezY26i0pNXpNkU79ESt6Tx800qu5ho4/Kfz2COvAYaJwDkGSLEeLt+2h1e2+Tjo8sy0N1NJriRJwmg0EovFMBgMLG1y8ZPwLjYFo7Bq+Pu88ruUXFDCQTvS12Z63dPJ0S0VhXzkNPOZ8EaqORMYmlzd+65KgTHK8q9qksKR5qokSdxdmc/qIgun92yktu96f0mY/ox/lYV4ylHIciyUj9LuxwlGo5FgYQlfthfhLzFw+zjvF5IKV/f2QC88t3TiqmZZlsktn49tYxLRIKB4W5HzZ68JzpglV4WFhaxevRqv14vX6+Wcc87JKH/88ce55ZZbst5BHY2NjXz44Yc0NjaSSCT48MMP+fDDD1MxZU4++WQWL17MF77wBdavX8/LL7/Mddddx6WXXpqSJF144YWYTCYuuugiNm3axD//+U/uvPNOrrnmmhSLvvzyy2loaOCaa65h69at/P73v+ehhx7iuuuum7Lfth8zi/6qQVEUOVDN40wlgqPxHQCaDH7etFroNKWlAf9fFtZsYCgSUVZWhqf8BP5it/HNgjB/2fNgqiypJrlloZHLiguJ5GvRnCeiRpgI9EW/OtdCsMBEjy0+yh2joP0jLloU5fvHGlm4aPokV0BG1Gzz/LO4b22Um17wjxh08WB/L2cEe1kopaXvM02u9G9vUcCUTBKL+FNlA8mVoijcs9rPjS9HcZRoVGk0ciXFNfIWTKQdkYaSXDXa4S2LhahF83j7/6AWBI1c5RQu4H2LmZ0WI9HY+OyuwlGFmvsCHPlQLzklNcDExpQkSdgcORz75zgV9wRo8c/e1DcwgSCiTqdzyEGVn58/pSfLm2++mRUrVnDLLbcQDAZZsWIFK1asSNlkiaLIs88+i9ls5qijjuKCCy7g7LPPzgih4HQ6efHFF2lubuaQQw7hiiuu4JprruGaa65J1amtreU///kPr732GgceeCB33HEH999/P5/+9Ken7Lftx8xioN1VuETzkqpONoCqckJHjNu7PNT0pjermd5w9iUM59141kXfxLO+F1Myiau7ESWpLZaemIdWs8SbsglD2VHA0LZbUwH9uxbnL+HB9k5+39oO6sSzTfh3vwnAFq88SEo/1eSqfyT4hUedyS1rDPxno5uNWzYOe8/nfN38qMtDuV2TMMx0jCsdBoOBz+2J8X5DM4d3p8nSQHL1fvv7zLl5DmVfKEs5D4ymFjy2w8Tb9U2c1ZIZikEnofozPt/k54ddHsrE0lHb/ThBlmUqqpaz6s02Dv1nI2p8fAeOVnc7TVGBdV0SOX02VxM5nOpx7joWlZE8p4S3u94ddxvTiX3m+P3www/z8MMPj1inqqqKZ555ZsQ6y5Yt4403RjbqXLVqFevWrRuxzn58fDAwmGjhQWfSsOlZ3i000dv8DD1NEubtPkxzNRvDqUpZ8nHFcCSiuLiY/xhP4D+Nr1Ckquzy7iDiWoIVK3t/tBfRIVL+k+mNtaTbgrjKFrGyOYwsCmwLdRG3lUyovTvMG0hWlHKEW2CgRepUh9QYmIFg5UkraVjcwD3+e/i9+nsMwoAxnIxTZtE2Tmu5Zus608bsOiRJIiZYAB9COO1kMNCgva17J9Y5VqyqmPqWI81VSZIQpXxsakNGChy9bUmSUuTq8HCIumCS5/qSWf9/Ilf5Lhe//WOAWCzGBZf3UmHNG/3GPqzuWs3iXy0mtjmWIuoTVQsCOBY6sBxgYUdgxyh3zCz27xD78f8eBoMhY6ObM38xf45bub3AxTOtz/CnLSKffTKMx6WlvtmvEhwfJEkadoP75Jeu5vmPtA1SevNuADwdHnq39aJsUlJOJNO5ycuyTElpGc09muQi5h4+KvVIUJIKLUaVZllGMmdSK5PJNOUSIVmWMzax4w4+BnutmagpSnNo76D6wc4dxCWBSFylYM6yVBuzAZIkEZO0oKByv5yPAyVXi93d/Ly9k+/ENHOR0QiQJEkkrZpEUU5kenoqipIR4uHhDSr3vxNFyJ+Tuvf/A2RZ1hwK+myZx+vkEevZDkCVKf0tJiq5AjhIMbFsg4dlHt+425hO7CdX+7EfMCiZrt2by0GRCIu9PficPkzlJlwF2kY/WzacfQWCIGS83/4oKCj4v/buPb6p+v4f+OvknFybNGkuvaStLRcFkZuCYkUFdAI68Dq8jo39FEXAOUGnKBNFRbYxplMnXsHpvl+cmzD86hQcDBQrCpbZInKpQEvb9N6kTdpcP78/Qk6bppe0TZqkeT8fjz4ecM7nfJJPPic57/P5fM7ng0PGq+HxMeg8x/Bh6avwHd+Bf9ysxEPT0wZ0p9tfUqkUCoUCX3FybFWn4LAl/OlgOpJ7ndhdVoHXq6phzJ0atG+wZtnvOO5q+uUzsLqyDp+UVyCzLPQJzR3lH+Ci/Fw8lGZAitofyMRLyxXP8yhTa/CgWof3DcGTfTLGxCBLY2vCtNY2ZPey9E3HfE/oJyKnWIFFnC5on9vtFvN1uB14vtqHX5cA8vQR4rHJIPDdyx9lxMQrUnGqtueen86utzRj38ly/KKhvd76E1wFjrma5/E/GjumW0/3OY/BRMEVIQgdd6U2FOCtqhrc3GyB8mdKDF85HCajf5FXCq76rqengufMvw/vHGK4KSMD7zTtwrv8Xpgu0GDcsPYL+2C3XAHADpMOvzEZcMDZv+4HSc0haH0+ZFpaMfy8C4P2DVZw1fG8NhhN8JyQwezxwl28NSRt3ZkFmzlX+2UhXs51nudxSDUKn5hS8YW6PajxeDxBg88lDv/kvw4uvOkSBEGARm9C2rXpYJNYyCztgeDqeMNx5D2Uh/zl+dDpdOJ7SgaB796EAjc8PzsLZYoDfTveWQ8VY+Al/ZtANCAwHMOb4p82Se2L75VQKLgiBKHjrjIn/RgfHXNjy3E3RrpcGM95YDT4F09Olu6ASFKpVN2OMUpLS8M3pnn4dmsdfNU+HFS3YnFmOo6ktS9WHYvgKs0uRUFrK9Ltjn7l01z6NQCgpJ4PWfVhsIKrzi2G9en+iZ+Huw4DnSZhvOSUHG8VncKkivb3Fk/BlVllRvWWauDr9u2dg6sTZ5a+aVKcWYMujJYrs96M+p31aPywEV74u6g5joPb7RbHdNltDWBVbeDqPOJnkizBVSCo0TI9znM6ke1s6/2gDlRnnsL0KAa+JqNUKgWvy0Urx6FV6erxyddYo+CKEPgv3h3HBeUNH4lffKrBlt3NeLa2Hn88aoFa0/NaZaR7HMf12Hp1y/w74Sx04btHvsOUajvOdrmQKrQPIh/sbkEAcFeMRtFTJ1B+bFS/8nnWVYNh+6V4o2FkyPiqwQquZDJZ0PmaPfVWfAUpXs7WYPuxN4PSvveDGpOeb8aX3suDjo8HgiDArDGj9p+1aC5sH3ju9XqDgqv3zf6lb07rUsTjesvXZDDiycZGbBAawDU3AfBP/upyucSWq7yGJpS01eBjR13QsclCKpVihDAamyurcW9tQ5+O/YdZgj/rtGhNM4nb+huYSqVSCKY8TMnLwT2jM9Dsjt/WKwquCEHouCCO4zC5YDK8K0dhXnYWjnulMRn/M5R0N41LYN/PfvozqATgdUc93q+wIDPVPx2ARCIZ1FaCQP0KphHYX+nDge9CB3/3ps3bhmO6Y1DPy4Im/7ygfRKJZFAvzB3P67wR5+DDNiXeS9VgZ33w2JnTp/3dgh3XRo2Xc53neWSmMOxfmIL/uyZ4jdeOE9Sanf6lbzRnlr7p7bzheR4pajVuGC3FnHOkcHRaAkccMG+rBgDYPELQsclCJpNBnuGf8d6kcAO+8KZj8DIvthlVeDlNC17nf8pyINN7SKVSpGaNgsHrg9Lng9XR9dqk8YCCK0LO6Dzu6uJJF0NjdyPV60WprH1fMt2xRpJEIul2CSkA+OlPf4qX5rZPXqnKjs3CwYHXu/zyyyGRSLC3cC/eObAB39TtDTsPL/PCt9eHxr2NmDBiQtA+hUIxqHNHdb5p0DpG4ie2Ziysag9SmtxNqL+gHoarDGJwFVh2Jh7wPI8UrQGjswVoMni43C3ivtbWVvHfq8tr8UFFFbJSwnuiL7D4cn2bBA6Og7WhPZDu2HLF7P7PqsXn79oerElt44VMJoM2ZxTcXoZjCilONxwM6zifx4F7m6yYZ2uGweifRHcgv59SqRT6jGy8fawC+06dhsHa2vtBMZI8Zwchveg87uqiCyfjfUc99pRV4DLWfqcWL3fziUiv13e7T61WozLfP1nviUYfTPn+4Cra80F1Fqjf4cOH47rrrsOcBSZ8iN14+9Tr4kSnvdE2nsTvW0/hlpJanDvIM7N31nncVfqEeVhR04DxDVagtQkAcLr+IBRTFJh4gwG5Of5Z8ePpPOd5HmpjNm7MzsLVudk4VtM+D2HH4Or5/cCaz5wQTL0vfQP4gySe5/FCjgFT8nPxH9dBcZ/X6xWDq92KMtydacIXaf7PMpkCK6B9epIdLTzuzkzH6hPrUdZyvNfjhOY63Ntkw0OWBhjMw8S8BvI+BEGAzc6BA9Bq6f09xEpynSGE9KBzcJWdk4t0rxc8gDqfRtxOLVf9JwiC+LRVV350yyJc++88PFFeANWZoGCwx/0EWjMAYPHixZAXtWCU04UF9dUQnNZejvZzHN2Na0bymDlSjpwzwUrAYAdXMpksqAvrvAsKMGkTh+HP2/DNYf8cXopqC+5ptGJmgx2GM2Pj4mW8FeAPrhRKFdQeL+Q+H6xN7d1BPp9/YL7X68X6z2x4bKcT6oxh4nG9EQQB0jNL4Ng9wWN4AoFbpdSOQqUSDTJF2PkOJYE5014qVCDX6UaO04UsX++fQaVDQN5zzZjxjgupZ2bMH2hwBQAPfZWOnPXNKLZ3f7MWaxRcEXIGz/MhrSTLfrgMG4tc2KW4BgDNzh4JPXUNqlQqrHn5f/DQ6vXitsFuQeE4TgygMzMzoR4/D7/+ugJ32KzIPPJOWHmU1xfBBaDCZ4zZYPaAzuMJpVIp8iZcBqlBis3HNsPqtkJnqcDSJiumnHLG5djCQH089X0N9p86jZH20MBvX9U+DPvNMGTdloW0tLSg43rLe2qVDPtOluOGiuB9gZnfr6z2YE1tHYa3hTdQfqgJnAsFc5bg1B9OYv/q49jwVs+roQBAeW0FTjs5nPa2fw8G8tkFjrXmpcN3Qyb2uvb1O69oo6sEIR107kK5denjqLt0NWbe9DMAyfejGg1KpTJkfFtPYtGC0vE177prIZ4u9F8Y0o6/D6nD0uOxDq8DvzE3Y0p+LurThofsH+xuTiD0vJ4+fTpyl+SifGQ5DjR+Ca7pJACgAToxTTy1XAVuaNrc/u+fx1YTkqai4QiUw5Qw5KvE72m4LVcSQQcVY5C5m7pMM6rFjrktDhhhFI9JJoHg6vrrr8e0eQ/iRJUXr776Kl555RUcKHsPRY1fd3ncLvsujNkwBvob9SF5DeR9qHPUMFxhQJm0rN95RRsFV4R00LlrUKVS4eqrrxYvNPF0N5/IepqWobNYfOYdX1On0yH/igXYdcKDwzIez3y3ElVt3S8BUtdaCa3PB6PXC7U5ePJQqVQaky6lzsHV1KlTMaXBgYn2NmhOFaHZWwUnBzjk7fNxxdO5HhhAHhhQ7rPXhaQZX2/Di5YaPOJ1BB3TG/8SOP7WVMFj7zLNp6fleH6fE9aUfADJ1y3YMZi84447sHz5cgDAkUOb8FzNP7C+dD1Ku1jrT+LyBz8jlO3HDyQwDawXOVGmwfhv6zHN0tL7QTFCwRUhHfTWohJPF5xEptFowv4sY9GC0vm9/fSn8/HbA3JsSNOiiLPj76c2dXvsSKcLe8oq8EppFbLHXBy0b7C7BAPkcnlQoKHRaHBpgxpv19TgotKDWHW2gAvzctFgzBLTxNu5zvM89qvVWK5Owy5paMtVqrUR01rbYD6z9E3gQhxOvse1E5FTosASQReynzGGdx0SPPIdhxb9ueIxyYTjuKDzYcGCBbjvvvvAyltxRYsDs+12XHboLyFTNCw53YR9J8sx1xGZ4Arwn5cTVBr8VWPHAmfPrcixRMEVIR10nky0s2TrDogWjuN6HHsVEKvpADoHFiqVCpOvX4zzD9TiWlsL7mJndXus/XghOAAnK73Iy88P2her4Kqr9R2deVcCAIx8JaRgkAAwmMaJ++OpWxDwnwsfIRfbTRrsk/pC9kta/a1Zdi5FTB8OQRCgMaQjbW46vBO8cPlcQfudPif423iMXD0Sam14y+oMRZ2/E3fffTdGXHkXvvtTOVZW1UF/ehdyvn4aYF4xjcprg4oxCIrItYhKpVJ4TGOw6P9a8cxXg9/FHi4KrgjpgOO4Hluv4u1uPpGlpaX12rIQq8+7q9e96aabsPELNf76m1N457Pul8RpqDyBZidDuUcfcoGPVXAFhHYNnjftBhyp80LPebGxqhpv/rcchryJAOJzHidBEJDuSUf1lmqknApdCLxUaMRXCjms8r6tpCAugfPvelj/ZYWv07JAbd5WcBYnvPUuGFMN4jHJpqtge8mSJci6dD5ufa8VLi+DrnwHPt7/K3xc/REAQCs500WraW8RHehnJ5VKkWo+G68ccGPLt00Dyiua4uvbQ0gc6Cm4SsY71mjheb7Hea+A2Az+BroOrqRSKa5bcD9OWRnefPNNNDU1hcx7ZffY8ViqBaPK1fgPpoTkEcvgqvN5bc7Oxv8163B5Xg7uyMjAlA0OpJv9E4hKpdJBneg0HIIgIFvIRu0/a4FjofvfzfbgzqwMVOn61rokCAIMej2esjbiz5I6yNqCA+cUF8O3rdX4zmaBQdu3VrGhpKvvBMdxeOCBB6C76Fbc8vdWfCGX4y1JHd46/TaONB/GK7lqvKTTQjC2T0w70PNKKpUiOzsbL7zwAl5//fW4XV+QgitCOqGWq8HTW9dgPLVcAcDs2bMxevRoODwO/OGzR/Dr4l8FdSOdcJyAXWeHZoIGI0aPDzqW47iYdrUplcqQC5tbcxE0Ph9S4cNZ48xiueOtSxDwX5jHpjZj/8IUPHjWtyH7c9rcGOZyI0Xm74LqS8uVLi0NNwaWwKkJXu7IUVcOALC7GFRaarnqjOM4/PrXv4Zs/I1Y/04j7mlowm1NSug4GT7QqvGWVgOVceATiAZIpVIoFApMnz4dY8aMibubgAAKrgjppPMTgx1Ry1VkyWQyaDSaHvfHQseJRDtvv//++7FgnAB7ej0sngZ83eEx9Bx5Dmo31aJmW03IzOxyuTymF4Kuurzzp/4Efyitws7ySszN0Irb4zW4UqtVOCdbgFznDGmxeLa8DtsqqpB+5om+vrRcSSQS1LZxaOE4NNaXBu13NvonLG1o4yIyV1Oi6ikw4jgOjz32GHyj5uLtP1ThiQeL8N3e3VjS2ISbG2wwmPN7zSNcifLZU3BFSCddTSYakChf7ETS07QMsWq56jiRaGdTp05FlexcPGypxytVNZjlav8ZVR/6CLvPa8GvpE4MHx48x1UsuwQDOo+7GnPeWBz6gYPLw2AymcTt8dhCy/M8JKkmXJKfi3tGZ8DhDe6+++N+Ds985gRvHCGmDzdfAHgx24iC/FzsbDsQtP8rx0EszDTh3bTUkGOSSW/nhEQiwapVq2CaOBtujwf/ePEFnHuwAZd93wRtBGZnD/d9xAsKrgjpQlddgzQ7e3SoVKpug9lYtqD01A1yx70P4ZvdNlzS1gbdNy8AZwZBe8r3Y5SRx/AsfchFIB6DK4lEgh2KubjyLw5g+AxxezxewARBQEpaNpQ+HxQ+Hxye9jmOGGN47nMbVnZY+ibcG6HA4H2p2//d7rwEjsVdgy+VSpR1OEcpuOoaz/N4+umnMXPmTOw+6cHJJh9OtMgi2uIXj+dmV+g2nJAuqFQqNDY2Bm2jVqvo4DgORqMRFRUVIfti+UPa02tPmDABf+cugs15EDqcQm35DpxIH4dy7iTSBQFWVV7IMfEQXHXV5b30/gdQcuVVmDBhgrgtXrsFVYYcfFZ8GnIGfDum/fv4RdUXyFuZB/thu/iQRF8CIJ7nUVAl4ClPOb5oSwvaN6FJgivb6lBT5//suusyHuokEgl4nofX6+0xnSAIWLt2LdxuNx74ZBfOHjcWb3TYN1CJEtjS1YKQLnTVcpUod0yJSKvVwmKxBP1wx2qOq4De6nvB4uVY/9wtmDMrFY9UbURdrQBvthxb3CZc7Z4Ykj4egiuJRAKVSgWHo71LTSqV4vzzzw9KF4/nOs/z0OgMcLYxyOUc2hoqoErxDzA/3XAEynwlFC0+MTDsy4VcEARwvBYqVhmyBI652YFZHgc+cviDtmRuvZZKpb0GV4F069atw9atWzFp0qSg7QMV6LL3eDy9J46h5D1LCOlBV5OJxuMFZ6iQSCQhTw7GuvWkt/oeMWIEjuivAt/sRj0PeOFFjtuN8Q4nTOdODUrL83zctHx27hrsSry81454ngfP82ho8//f2di+BNEF9Q68ZKnBY2gPGvtSBqlUCq/CHzwJ7uAlcEqsKjz3pRMnWE6f8x1q+vKdlMlkuPnmmzFixAhxW6Q+u0T4LabgipAudPVkVSJ8oRNZ5zmv4j24AoD/t+iX+N/dTjx1shp/PSnBv05X4briWow4e1RQunhotQroLbiKxzmugPbuoG0K/xI4Xzm+F/elWhtweWsbTNb2LqO+tDDxPI8jqecju0SBpXJt0L7tTmDFYQ5H5P46TebgaqC/gZH67GL92xAOCq4I6Ubn4CqZf1QHgyAI0Ol04v9j/QMazoUkKysLDSNvxC1r6rCj0P8If6lDEzJAP56Cq0RdPzMQLL3mMGC7SYOD3jZxH+fwL33jkLRP8tmXAFEQBGgNGdDPTYf7PDfaOuRddWEVRq4eCYmpfc3CZBUvwVW8nqMdUXBFSDeo5WrwdewajPXnHe7r//zOeyCRq1Fpc+OgxYs6eXwOZg+QSCQ9vp9YB7Xd4TgOPM8jpSYF1e9XQ2fVifuOSuuxTyGHTeafLqGvARDP88jUZ6J+Rz1atreAoX0OLandB2+TG+mq5J1ANGAg50YkZmcPSIQbXQquCOlG5yerEuELneiUSqUY1Mb6Ih/uU2FpaWlYsGAB1he6cP4rdlgyrwhJE0/BFQCo1epu98X6c+8Jz/MwtZhQu60W8pr21sH/NXtwV1YGqrX+CWn7+l31L4GThqebG/ESaqDsMFj6w9rT+K6xCmMV7e8hWQ3khieSv5+xvvEKBwVXhHSD5/mgCw0FV4MjMJllrNYVDOhpItHO5s+fL06GOnHixJD9sS5LZ4m6xBPP87gmx78EzgzfZ+L23DYPhrvcUMvSAfS9DDzPQ28w4qZzpbjmbAFttSf9OxhDmszfiiVP8y8+nMy/AwM5NyJ5XsXzORqQvGcJIWFISUmBy+VfOy6Zf1QHk0ajwbnnnhsXLQQymQxut7vXdCqVChs3bkRZWRnGjBkTkke8Pb7f06D2eL5wCYIAvYrH2VoBlpYGcfvvymthVnnxbupcAH1vXRIEAVKpFDWtHHglh8a648jKGQe47ZCf+dqr9Nn9ynso4Xk+ZCqPcCVbcBVf33hC4kzgDp9mZx9c8XIB68uPeH5+Pi6//PKQ7fHWJQj0vMRTPF+4eJ6HRavC1LxcrDmnvVX5+QMCnt7jBG/wP/bf1xshcQkcswEF+bn4xPEVAKC46kvclZmOdVot1PqMoLTJiOM4ZGdn92vsVCRvThPhRpeuFoT0IBBcJcKXmUReOHNC9SYegyug+3FX8RxcCYKAFIW/29gj8S97wxjD83tt+M0uJ9QZ+QD613IFADKXP2hwuK0AgArrD9inVOBbqQzSM0MEkjm4Avxd3JmZmX0+LpLnVeDhhnhGwRUhPQh06cTzIF8SPTqdbsCBdbwGV12Nu4r1rPi94XkeWlU29p8sw7bvK8FxHPZa9iJnRQ4y5mWIT5v2tc4CDy9cVMXjq5Pl+EmV//izWnisqanDLEv7xKJ0o+Wfk66rpZR6EunPLZ5vAgAKrgjpEcdx0Ol0EWnBIImH4zikp6cPKI94Da66Oqfj/SaC53kodWbIGaCT+wDGUN7wPZT5ShiyleIFvz+tGjzPAxItlIxBcPrXFU1rsWOu3YGRDcHLMiU7juOQk5PTp+7BSAdD8R5cUQhOSC/MZnOs3wKJIZ1Oh5qamn6tZcZxXNxeBARBgEwmEx/YABIkuDKYgeOAnAc4jwMXNjgx21aDig4xT39aSQRBEJfA4c8sgXPaIcdzXzrBdFm46ky6eG7ZG0xyuRwZGRmwWCxhpaeWK0IIISKJRCJOD9FXCoUiLpeSCejcehXvFyye56FOy8ArshQsU+twpL4YWmsjLmttg6HD0jf9Da6+U09EdokCv1JqwRjDPqcbK77n8ElrPoDw5z5LFgaDIezuQQqu4tQzzzyDSy65BCqVKmiJjI44jgv527BhQ1Ca4uJiTJs2DUqlEtnZ2Vi9ejUYY0Fpdu/ejUmTJkGhUGD48OEheRBCkktaWlq/uoPitUswINGCK0EQoEpJwdpGOXaYUvG9vQacoxYAYOfay9KfuhIEATq9fwmcttFtaPW1othUjJFPjoRkBC1905VA92BvIjk7e4BMJhOv8/EoYboFXS4X5s2bh4KCArzxxhvdptu4cSNmz54t/l+rbV+E02az4aqrrsKMGTPw9ddf4+jRo1iwYAFSUlKwfPlyAMCJEydwzTXXYOHChXjnnXewd+9eLF68GCaTCTfddFP0CkgIiVuB1qtwu0AC4j246jyoPRG6BTmOg6fYg+qj1dDcrsFhoR4KmRw2uX929v62LvE8jwxDBuo+qoNKogImAtI2D7zMjbQzy+rQYPZQge7B6urqbtNE43NLTU3FyJEj47abNmHOlCeffBIAsGnTph7T6XS6bh8T/etf/4q2tjZs2rQJcrkcY8eOxdGjR7F+/XosW7ZMbOk666yz8NxzzwEAzj33XOzfvx/r1q2j4IqQJKbX61FbWwuv19t74jPiPbiSyWQQBEEcTxbvLVeBliNFqQKnj5+GYo4CG7M9+LOQgf9n0wal6StBEGBI0+JZexOyUluQ4mNYX1mFC3RW/I0fI6YhoYxGI6xWK9ra2rrcH43ziuO4uFv5oKP4DPkGYOnSpTAajbjwwguxYcMG+Hw+cV9hYSGmTZsWVCGzZs1CZWUlTp48KaaZOXNmUJ6zZs3C/v37u52p2el0wmazBf0RQoYWiUQiLnETrngProDg+a7iPbgKtEotm+zBgbtTYK7bjfxWN0a4XEg5s/RNfwMgnuehN6bjJ2OkmDVcAndjBVI4f7DApRjFNCRUb92D8X5eRcOQCq6eeuopvPfee/j0009x6623Yvny5VizZo2432KxICMjI+iYwP8Dzf3dpfF4PKirq+vydZ999llotVrxLzc3N5LFIoTECb1eH3Y3hCAICXExDoy7kkgkCfF+JRIJslN5jMwW4HZVYV1ZLbZWWJCq9v/u9vdCLggCVCoVqu1AM8ehvuYYNIL/hprX+B9oSITPJ1YUCkW305YkY4tfTIOrJ554ostB6B3/9u/fH3Z+K1euREFBASZOnIjly5dj9erV+P3vfx+UpnNffGAwe8ft4aTpaMWKFbBareJfeXl52O+ZEJI4eJ4Pu/UqEVqtgPZxV4nSusDzPIpM/iVw3jLV4flvpHhqjxMS43Bxf38EAoCXsvS4JD8X/2PfiZXDjFhp1EOmo0Wbw2EymbrsqkvGzy2mJV66dCluvfXWHtPk5+f3O/+LL74YNpsN1dXVyMjIQGZmZsiA1JqaGgDtLVjdpREEQZz9tzO5XB7Xfb+EkMgxGAyoq6sLGnLQlUQJrmQyGXiej/vB7AGCIEAGFQA7XJwXLxa2wOFw4sMH88X9/REIymQuf5uDhTWgLEWBTI8H09PMQWlI1ziOQ25uLo4fPx60PVEC90iKaXBlNBr7PIahL4qKiqBQKMSpGwoKCvDoo4/C5XKJPyTbt2+H2WwWg7iCggJ88MEHQfls374dkydPTsoThBASjOd5GAwG1NbW9pguUYIrjuOQlZWVMK0LgiAgx23E/pOH8brPiCMPZ6H5v83Q6/Xi/v7mCwCTKjmsYuXY6zsHbeo6eH2Aeoy/5YqCq94FugcDDRdAcrZcJcyYq7KyMhw8eBBlZWXwer04ePAgDh48iJaWFgDABx98gNdeew0lJSUoLS3F66+/jsceewx333232Kp0++23Qy6XY8GCBSgpKcGWLVuwZs0a8UlBAFi0aBFOnTqFZcuW4fDhw3jzzTfxxhtv4MEHH4xZ2Qkh8cVoNPb6uH+iBFeA/ynr7hZyjjc8z0NQGSFnQJvKDWWeEoYshTh2rL8BkDiWTpIKJWPIbbVgjt2BKbV2pJz5bCi4Co/RaAzqzUnG4CphSvz444/jrbfeEv9//vnnAwB27dqF6dOnQyqV4s9//jOWLVsGn8+H4cOHY/Xq1ViyZIl4jFarxY4dO7BkyRJMnjwZaWlpWLZsGZYtWyamGTZsGD766CM88MADeOmll2A2m/GnP/2JpmEghIgCY696ar2ioQLRwfM8JGoj0Azc4WrBRRYnKmRMDHb7eyHnOA48z8MtTwMAtLY58cdvnZBIlbhygHknG4lEgpycHJSWlgJIzs8tYUq8adOmHue4mj17dtDkod0ZN24c9uzZ02OaadOm4ZtvvunrWySEJJHA2KvOKzwA/sAqXmeOTnQ8z0OqzcR6nwY2hRRLmprgsCmC9g8k7xLVRGQfOgTVOak4/b0N2RoDroxA3slGqVQiPT0dTU1NcTvRZzQlTHBFCCHxJPCQS1dTtCRSl2CiEQQBEuNIvGJNgSxVhpuaW4KWvhlIK4l/CZxM6Of4pxQY+eRI8F+2B1QUXPVNenp6v9flTHTJF04SQkiEdDf2ioKr6OF5HjqdDg3/bkB6YxuOyaRolmmC9veXIAgw6U2o+5c/YGZtXqjhX5iY47ikbIEZqGRtwaUzhRBC+kkQBPEptY4ouIoenueh1WpR9686WNVSrDIZ0Kj2r/030ABIEAQY9Vo829aE4hNlKKmqwDLOAQAUWJE+obOFEEIGoKvpZCi4ih6e5yGVSrHxJjUmetwY6XJBJfPPUzjQgdM8z0NvSMct57VPu+OWaiKSN0kudLYQQsgASKVS6PV6NDQ0APC3cNCFOHoC3X5jTAJuqKkFwOEDdXbQvv4SBAGpWi0sdgaD3t/24FPoIpI3SS7UckUIIQPUsfVKoVAk7TiTwRAIcv5u1uHSvFysUWshMfiXvhnoRM+CIIDjOLyUacDUvFxMzctFW4pO3EdIuCi4IoSQAZLJZEhL88+PRF2C0SWRSMBxHGQuf5B1sJFBnZ4HYOCtS4HjvZ72S6MsxRiRvElyoVCcEEIiwGQyobGxEUqlMtZvZcjjeR5ja6V4nC/D8/ucMMz2r/s60NalwPFTKny4TFGPNo6DQpsdkbxJcqGzhRBCIkAmk+Gcc86hNUgHAc/z0MjkkAG4MFtAaqr/acFIDGgHABnUuLGlHADwUT4t2kz6jroFCSEkQmQyGY23GgSCIMCo9M+MPz2PFz/zSAxoBwCvTCtuU+lp0WbSdxRcEUIISSg8z2OX5DJ8edqDh/elidsH2nIVmCfrG9lFUDxtA/ekDVpdmviahISLgitCCCEJRRAEpOaOQcEbDpRIzgvaPlA8zyNVnw6nF1Cr1WI3L425In1BZwshhJCEwvM8Lr30UmzYsAFjxowJ2j5QgiCIU2vodLqI5k2SBwVXhBBCEgrP85BIJJg6dWrQ9ki0LgmCgAsuuABXXnllUP4UXJG+oOCKEEJIQukq0InUwso8z0Mul+O5557r9TUJ6Q6NuSKEEJJQugp0IhX8dNX6FZi4lJBwUXBFCCEkoXQVAEU7uCKkL+iMIYQQklC6CqQiNXlrV3nTk4Kkryi4IoQQklCiGQB1lQ8FV6SvKLgihBCSUKI55iqaeZPkQcEVIYSQhNLVk4HRbLmi4Ir0FQVXhBBCEk7n4CqaLVfULUj6ioIrQgghCadzwBOpAKirJwOp5Yr0FQVXhBBCEk60giuO40KCKQquSF9RcEUIISThRDMA6hyoUXBF+oqCK0IIIQmnc8ATyXFR0WoVI8mDgitCCCEJp3NwFclZ1KnligwUBVeEEEISTscAiOf5iK79R8EVGSgKrgghhCScjgFPpLvtotkqRpIDnTGEEEISTjSDq2i2ipHkQMEVIYSQhDNYLVfUJUj6g4IrQgghCSeaAVDnlitC+oqCK0IIIQmnYwAUzZYrmoaB9AcFV4QQQhJOx0Hm0R5zRUhfUXBFCCEk4XAcJwZYkQ6AqOWKDFRCBFcnT57EnXfeiWHDhkGpVGLEiBFYtWoVXC5XULqysjLMnTsXKSkpMBqN+OUvfxmSpri4GNOmTYNSqUR2djZWr14NxlhQmt27d2PSpElQKBQYPnw4NmzYEPUyEkII6ZtAEBTpACiagRtJDgkRkn///ffw+Xx45ZVXMHLkSJSUlGDhwoWw2+1Yt24dAMDr9eLHP/4xTCYTPv/8c9TX1+PnP/85GGN44YUXAAA2mw1XXXUVZsyYga+//hpHjx7FggULkJKSguXLlwMATpw4gWuuuQYLFy7EO++8g71792Lx4sUwmUy46aabYvYZEEIICSYIAtxud1QCIJ7n4fP5KLgi/cKxzs02CeL3v/89Xn75Zfzwww8AgH/961+YM2cOysvLYTabAQCbN2/GggULUFNTg9TUVLz88stYsWIFqqurIZfLAQBr167FCy+8gNOnT4PjODz88MPYtm0bDh8+LL7WokWL8N///heFhYVhvTebzQatVgur1YrU1NQIl5wQQgjg79VoaWnB6NGjI956VVpaitbWVuTm5kKr1UY0bxK/InX9Tohuwa5YrVbo9Xrx/4WFhRg7dqwYWAHArFmz4HQ6ceDAATHNtGnTxMAqkKayshInT54U08ycOTPotWbNmoX9+/fD7XZ3+V6cTidsNlvQHyGEkOgKBFTRaF2SSqVRy5sMfQkZXJWWluKFF17AokWLxG0WiwUZGRlB6dLS0iCTyWCxWLpNE/h/b2k8Hg/q6uq6fD/PPvsstFqt+JebmzuwAhJCCOkVz/NRm0E9WuO5SHKIaXD1xBNPgOO4Hv/2798fdExlZSVmz56NefPm4a677gra19UXjDEWtL1zmkCvaF/TdLRixQpYrVbxr7y8vLeiE0IIGSCtVov09PSo5B3NVjEy9MU0JF+6dCluvfXWHtPk5+eL/66srMSMGTNQUFCAV199NShdZmYm9u3bF7StsbERbrdbbInKzMwUW6gCampqAKDXNIIgwGAwdPke5XJ5UFcjIYSQ6FOpVFCpVFHJOxBUUXBF+iOmwZXRaITRaAwrbUVFBWbMmIFJkyZh48aNIauUFxQU4JlnnkFVVRWysrIAANu3b4dcLsekSZPENI8++ihcLhdkMpmYxmw2i0FcQUEBPvjgg6C8t2/fjsmTJ4t98IQQQoa21NRU+Hy+kGsNIeFIiLOmsrIS06dPR25uLtatW4fa2lpYLJagFqaZM2dizJgxmD9/PoqKivDvf/8bDz74IBYuXCiO+L/99tshl8uxYMEClJSUYMuWLVizZg2WLVsmdvktWrQIp06dwrJly3D48GG8+eabeOONN/Dggw/GpOyEEEIGn0wmi1qXIxn6EmIqhk2bNuEXv/hFl/s6vv2ysjIsXrwYO3fuhFKpxO23345169YFddkVFxdjyZIl+Oqrr5CWloZFixbh8ccfDxpPtXv3bjzwwAM4dOgQzGYzHn744aDB872hqRgIIYSQxBOp63dCBFeJhoIrQgghJPEk/TxXhBBCCCHxiIIrQgghhJAIouCKEEIIISSCKLgihBBCCIkgCq4IIYQQQiKIgitCCCGEkAii4IoQQgghJIIouCKEEEIIiSAKrgghhBBCIoiCK0IIIYSQCKLgihBCCCEkgoRYv4GhKLBco81mi/E7IYQQQki4AtftgS67TMFVFDQ3NwMAcnNzY/xOCCGEENJXzc3N0Gq1/T6eYwMNz0gIn8+HyspKaDQacBwX0bxtNhtyc3NRXl4+oBW74x2Vc+hIhjICVM6hhso5dPSljIwxNDc3w2w2QyLp/8gparmKAolEgpycnKi+Rmpq6pD9InRE5Rw6kqGMAJVzqKFyDh3hlnEgLVYBNKCdEEIIISSCKLgihBBCCIkgCq4SjFwux6pVqyCXy2P9VqKKyjl0JEMZASrnUEPlHDpiUUYa0E4IIYQQEkHUckUIIYQQEkEUXBFCCCGERBAFV4QQQgghEUTBFSGEEEJIBFFwRQghhBASQRRcxcCePXswd+5cmM1mcByHrVu3Bu2vrq7GggULYDaboVKpMHv2bBw7diwojcViwfz585GZmYmUlBRccMEF+Pvf/x6UprGxEfPnz4dWq4VWq8X8+fPR1NQU5dK1G6xy5ufng+O4oL9HHnkk2sUDEJkylpaW4oYbboDJZEJqaipuvvlmVFdXB6UZCnUZTjljWZfPPvssLrzwQmg0GqSnp+P666/HkSNHgtIwxvDEE0/AbDZDqVRi+vTpOHToUFAap9OJ++67D0ajESkpKbj22mtx+vTpoDSxrM/BLOdQqM9XX30V06dPR2pqKjiO67KehkJ9hlPORK/PhoYG3HfffRg1ahRUKhXOOuss/PKXv4TVag3KJxL1ScFVDNjtdkyYMAEvvvhiyD7GGK6//nr88MMP+Oc//4mioiLk5eXhRz/6Eex2u5hu/vz5OHLkCLZt24bi4mLceOONuOWWW1BUVCSmuf3223Hw4EF8/PHH+Pjjj3Hw4EHMnz9/UMoIDF45AWD16tWoqqoS/1auXBn18gEDL6PdbsfMmTPBcRx27tyJvXv3wuVyYe7cufD5fGJeiV6X4ZYTiF1d7t69G0uWLMGXX36JHTt2wOPxYObMmUHn4+9+9zusX78eL774Ir7++mtkZmbiqquuEhdrB4Bf/epX2LJlCzZv3ozPP/8cLS0tmDNnDrxer5gmlvU5mOUEEr8+HQ4HZs+ejUcffbTb1xoK9RlOOYHErs/KykpUVlZi3bp1KC4uxqZNm/Dxxx/jzjvvDHqtiNQnIzEFgG3ZskX8/5EjRxgAVlJSIm7zeDxMr9ez1157TdyWkpLC/vKXvwTlpdfr2euvv84YY+y7775jANiXX34p7i8sLGQA2Pfffx+l0nQvWuVkjLG8vDz2xz/+MWrvPVz9KeMnn3zCJBIJs1qtYpqGhgYGgO3YsYMxNjTqMpxyMhY/dckYYzU1NQwA2717N2OMMZ/PxzIzM9natWvFNG1tbUyr1bINGzYwxhhrampiUqmUbd68WUxTUVHBJBIJ+/jjjxlj8Vef0SonY4lfnx3t2rWLAWCNjY1B24dCfXbUXTkZG1r1GfC3v/2NyWQy5na7GWORq09quYozTqcTAKBQKMRtPM9DJpPh888/F7ddeumlePfdd9HQ0ACfz4fNmzfD6XRi+vTpAIDCwkJotVpMmTJFPObiiy+GVqvFF198MTiF6UGkyhnw29/+FgaDARMnTsQzzzwDl8s1KOXoSThldDqd4DguaOZghUIBiUQiphkKdRlOOQPipS4DXQV6vR4AcOLECVgsFsycOVNMI5fLMW3aNLEeDhw4ALfbHZTGbDZj7NixYpp4q89olTMgkeszHEOhPvtiqNWn1WpFamoqBEEAELn6pOAqzowePRp5eXlYsWIFGhsb4XK5sHbtWlgsFlRVVYnp3n33XXg8HhgMBsjlctxzzz3YsmULRowYAcA/Vik9PT0k//T0dFgslkErT3ciVU4AuP/++7F582bs2rULS5cuxXPPPYfFixfHolhBwinjxRdfjJSUFDz88MNwOByw2+146KGH4PP5xDRDoS7DKScQP3XJGMOyZctw6aWXYuzYsQAgftYZGRlBaTMyMsR9FosFMpkMaWlpPaaJl/qMZjmBxK/PcAyF+gzXUKvP+vp6PPXUU7jnnnvEbZGqTyHslGRQSKVS/OMf/8Cdd94JvV4Pnufxox/9CFdffXVQupUrV6KxsRGffvopjEYjtm7dinnz5uGzzz7DuHHjAAAcx4Xkzxjrcvtgi2Q5H3jgATH9+PHjkZaWhp/85CfiHVashFNGk8mE9957D/feey/+9Kc/QSKR4LbbbsMFF1wAnufFdIlel+GWM17qcunSpfj2229DWtWA0LoIpx46p4mX+ox2OYdqffaWR3/zGahol3Mo1afNZsOPf/xjjBkzBqtWreoxj57y6Q4FV3Fo0qRJOHjwIKxWK1wuF0wmE6ZMmYLJkycD8D919eKLL6KkpATnnXceAGDChAn47LPP8NJLL2HDhg3IzMwMeRILAGpra0Mi+1iJRDm7cvHFFwMAjh8/HtPgCui9jAAwc+ZMlJaWoq6uDoIgQKfTITMzE8OGDQOAIVGXQO/l7Eos6vK+++7Dtm3bsGfPHuTk5IjbMzMzAfjvbLOyssTtNTU1Yj1kZmbC5XKhsbExqFWnpqYGl1xyiZgmHuoz2uXsSqLVZziGQn32V6LWZ3NzM2bPng21Wo0tW7ZAKpUG5ROJ+qRuwTim1WphMplw7Ngx7N+/H9dddx0A/1MdACCRBFcfz/Pik1cFBQWwWq346quvxP379u2D1Wrt8ccvFgZSzq4EniTs+AWLte7K2JHRaIROp8POnTtRU1ODa6+9FsDQqMuOuitnVwazLhljWLp0Kd5//33s3LkzJOgbNmwYMjMzsWPHDnGby+XC7t27xXqYNGkSpFJpUJqqqiqUlJSIaWJdn4NVzq4kWn2GYyjUZ38lYn3abDbMnDkTMpkM27ZtCxorCkSwPsMe+k4iprm5mRUVFbGioiIGgK1fv54VFRWxU6dOMcb8Ty/s2rWLlZaWsq1bt7K8vDx24403ise7XC42cuRIdtlll7F9+/ax48ePs3Xr1jGO49iHH34opps9ezYbP348KywsZIWFhWzcuHFszpw5Q6qcX3zxhZjvDz/8wN59911mNpvZtddemxBlZIyxN998kxUWFrLjx4+zt99+m+n1erZs2bKgNIlel+GUM9Z1ee+99zKtVsv+85//sKqqKvHP4XCIadauXcu0Wi17//33WXFxMbvttttYVlYWs9lsYppFixaxnJwc9umnn7JvvvmGXXHFFWzChAnM4/GIaWJZn4NVzqFSn1VVVayoqIi99tprDADbs2cPKyoqYvX19WKaoVCfvZVzKNSnzWZjU6ZMYePGjWPHjx8PyifS308KrmIg8Khr57+f//znjDHGnn/+eZaTk8OkUik766yz2MqVK5nT6QzK4+jRo+zGG29k6enpTKVSsfHjx4dMWVBfX8/uuOMOptFomEajYXfccUeXj9dGy2CU88CBA2zKlClMq9UyhULBRo0axVatWsXsdnvClPHhhx9mGRkZTCqVsrPPPpv94Q9/YD6fLyjNUKjL3soZ67rsqnwA2MaNG8U0Pp+PrVq1imVmZjK5XM4uv/xyVlxcHJRPa2srW7p0KdPr9UypVLI5c+awsrKyoDSxrM/BKudQqc9Vq1b1ms9QqM/eyjkU6rO73zEA7MSJE2K6SNQnd+ZNE0IIIYSQCKAxV4QQQgghEUTBFSGEEEJIBFFwRQghhBASQRRcEUIIIYREEAVXhBBCCCERRMEVIYQQQkgEUXBFCCGEEBJBFFwRQgghhEQQBVeEEEIIIRFEwRUhhBBCSARRcEUIIYQQEkH/H+33e35YVEp+AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.fill_between(years, np.min(specific_mb_all, axis=0), np.max(specific_mb_all, axis=0),\n",
+    "                 color='lightgray', label=f'range MCS sample')\n",
+    "\n",
+    "plt.plot(years, specific_mb_default, '-k', label='control run (default)')\n",
+    "plt.plot(years, np.median(specific_mb_all, axis=0), 'C1--', label='median MCS sample')\n",
+    "plt.plot(years, np.mean(specific_mb_all, axis=0), 'C2:', label='mean MCS sample')\n",
+    "plt.title('Example of the uncertainties generated with MCS')\n",
+    "plt.ylabel('Specific MB (mm w.e.)')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6798932d-3162-44d0-92d1-1e3796d00274",
+   "metadata": {},
+   "source": [
+    "# Bonus: Get sensitivities (not needed at this stage of DTC-Glaciers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc0c9a6c-94fd-49dc-94aa-2b51b475af15",
+   "metadata": {},
+   "source": [
+    "This is not needed at the moment. But the idea is that you also can analyze how much of the variance of a result is comming from the observations and how much from the model parameters. This could become interesting in a next phase of DTC-Glaciers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "e979491e-310c-43d2-a8c0-00c6fafc26ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compare how much of the variance for one year is comming from the observation and how much from the model\n",
+    "yr = 2000\n",
+    "\n",
+    "# now get values from MCS runs\n",
+    "specific_mb_yr = []\n",
+    "for i in range(param_values.shape[0]):\n",
+    "    mb_mod = MonthlyTIModel(gdir, settings_filesuffix=f'_{i}')\n",
+    "    specific_mb_yr.append(mb_mod.get_specific_mb(fls=fls, year=yr))\n",
+    "specific_mb_yr = np.array(specific_mb_yr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "6a688c68-fe62-43fb-93d1-1027964c2b33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import SALib.analyze.sobol as analyser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "783534f7-b20c-4f54-9e55-d8845d949b19",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                 ST   ST_conf\n",
+      "ref_mb     0.069132  0.032055\n",
+      "prcp_fac   0.959213  0.480933\n",
+      "melt_f     0.121303  0.084683\n",
+      "temp_bias  0.137700  0.103872\n",
+      "                 S1   S1_conf\n",
+      "ref_mb     0.092887  0.140456\n",
+      "prcp_fac   0.702130  0.488540\n",
+      "melt_f     0.196756  0.183623\n",
+      "temp_bias  0.061604  0.192858\n",
+      "                             S2   S2_conf\n",
+      "(ref_mb, prcp_fac)     0.019816  0.263528\n",
+      "(ref_mb, melt_f)      -0.101128  0.186669\n",
+      "(ref_mb, temp_bias)   -0.095322  0.200636\n",
+      "(prcp_fac, melt_f)    -0.025813  0.641291\n",
+      "(prcp_fac, temp_bias)  0.047332  0.615218\n",
+      "(melt_f, temp_bias)   -0.026448  0.307664\n"
+     ]
+    }
+   ],
+   "source": [
+    "Si = analyser.analyze(problem, specific_mb_yr, print_to_console=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "135444d6-1631-402f-9453-61bd76d297d4",
+   "metadata": {},
+   "source": [
+    "How to read this (from my amateur point of few, without digging into the references):\n",
+    "\n",
+    "In the first order sensitivities we see the larges portion of the sensitivity of the 2000 specific mass balance is comming from the precipitation factor followed by the melt_factor.\n",
+    "\n",
+    "To get a more indepth understanding have a look at the references provided in the docstring `analyser.analyze?`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "d10dd9f4-0e00-4f03-94f8-2307308448e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# analyser.analyze?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0b925f2-866a-483f-a52d-c4fe1f8fddc8",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:oggm_env]",
+   "language": "python",
+   "name": "conda-env-oggm_env-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/05_mcs_workflow_example.ipynb
+++ b/notebooks/05_mcs_workflow_example.ipynb
@@ -5,7 +5,17 @@
    "id": "aa98ae2e-64a1-4b4b-a457-2e348c512954",
    "metadata": {},
    "source": [
-    "**Important**: This notebook only works together with the oggm dev branch at the moment."
+    "**Important**: This notebook only works together with the oggm dev branch at the moment and requires SALib to be installed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26446826-e30d-4712-b909-1d39f92d25c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!pip install SALib"
    ]
   },
   {
@@ -19,7 +29,10 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from oggm import utils, workflow, tasks, cfg\n",
-    "from oggm.core.massbalance import MonthlyTIModel"
+    "from oggm.core.massbalance import MonthlyTIModel\n",
+    "\n",
+    "import SALib.sample.sobol as sampler\n",
+    "import SALib.analyze.sobol as analyser"
    ]
   },
   {
@@ -292,16 +305,6 @@
    "metadata": {},
    "source": [
     "Creating the actual sample is quite easy again. For more information on the sampling method you can read up the references provided in the sampler docstring `sampler.sample?`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "de28f5c9-1b35-4ff4-9418-169232c82f0e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import SALib.sample.sobol as sampler"
    ]
   },
   {
@@ -2209,16 +2212,6 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "6a688c68-fe62-43fb-93d1-1027964c2b33",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import SALib.analyze.sobol as analyser"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 25,
    "id": "783534f7-b20c-4f54-9e55-d8845d949b19",
    "metadata": {},
@@ -2284,9 +2277,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:oggm_env]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-env-oggm_env-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2298,7 +2291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.10.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Here I add a first example notebook demonstrating how the Monte Carlo Simulation (MCS) can be used to propagate observation and model uncertainty to the outputs.

At the moment, it only works with the OGGM dev branch, which includes the new handling of settings and observations. The workflow presented here builds upon those developments.

This workflow is just a first example, and in particular, the definition of parameter distributions will require more careful work depending on the use case. However, first results already look promising for this example:

<img width="599" height="433" alt="image" src="https://github.com/user-attachments/assets/426c1368-948c-4c9b-b8e0-36a33e893de5" />
