### PR TITLE
add more info to mcs notebook

### DIFF
--- a/notebooks/05_mcs_workflow_example.ipynb
+++ b/notebooks/05_mcs_workflow_example.ipynb
@@ -135,6 +135,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "d92e8cc0-b38c-46c6-865b-4c5309fb454e",
+   "metadata": {},
+   "source": [
+    "Notes on the new handling of settings and observations:\n",
+    "\n",
+    "- **Observations**: In observations, the convention is that the variable name should match the function’s kwarg. For example, `tasks.mb_calibration_from_scalar_mb` has the kwargs `ref_mb`, `ref_mb_period`, and `ref_mb_err`. Therefore, in the observations we use the key `ref_mb`. The actual value is stored under `observations['ref_mb']['value']`, and the other parameters are stored without repeating `ref_mb`. For example, `ref_mb_period` is stored as `observations['ref_mb']['period']`.\n",
+    "- **Settings with a parent file**: A settings file can have a parent. If a parameter is not found in the current file, it will be taken from the parent. By default, the parent is `cfg.PARAMS`. You can change this by setting `parent_filesuffix`. In my example, I use this feature to ensure all parameters are consistent with the default calibration.\n",
+    "- **Calibrated parameters**: After calibration, the parameters are written back into the settings file with the chosen `settings_filesuffix`. This means that after running `tasks.mb_calibration_from_scalar_mb`, you will find the calibrated parameters in the settings under this suffix. In some cases, the initial guess of a parameter may also come from the settings and later be overwritten with the calibrated values. In the future, we might want to add safeguards for this."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "ed66f28b-ddd9-493b-9536-dc3aa15d2732",
@@ -2251,7 +2263,7 @@
    "source": [
     "How to read this (from my amateur point of few, without digging into the references):\n",
     "\n",
-    "In the first order sensitivities we see the larges portion of the sensitivity of the 2000 specific mass balance is comming from the precipitation factor followed by the melt_factor.\n",
+    "In the first order sensitivities S1 we see the largest portion of the sensitivity of the 2000 specific mass balance is comming from the precipitation factor followed by the melt_factor.\n",
     "\n",
     "To get a more indepth understanding have a look at the references provided in the docstring `analyser.analyze?`."
    ]


### PR DESCRIPTION
Here I add a few more explanations about the new settings and observations handling of OGGM, and how I used it for MCS. 

The current MCS notebook is meant to be used more for internal usage and not to be made public as a DTC-Glaciers tutorial (but maybe at some point we also can think of adding a notebook explaining how uncertainty propagation is done, but maybe only after MCS is integrated in dtcg)